### PR TITLE
update: add recurring tasks tips on first task creation

### DIFF
--- a/lib/presentation/onboarding/onboarding_screen.dart
+++ b/lib/presentation/onboarding/onboarding_screen.dart
@@ -51,7 +51,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       const _OnboardingPage(
         lottieUrl: 'assets/lottie/calendar.json',
         title: 'スマートな日付入力',
-        description: 'タスクに "tomorrow" と入力すれば明日のタスクに\n"everyday" で毎日繰り返すタスクを作成\nTeuxDeuxスタイルの自然な入力をサポート',
+        description: 'タスクに "tomorrow" と入力すれば明日のタスクに\n"every day" で繰り返しタスクも簡単に作成',
         fallbackIcon: Icons.edit_calendar_outlined,
       ),
       const _OnboardingPage(

--- a/lib/services/local_storage_service.dart
+++ b/lib/services/local_storage_service.dart
@@ -1,11 +1,8 @@
 import 'package:hive_flutter/hive_flutter.dart';
 import '../services/logger_service.dart';
 import '../models/todo.dart';
-import '../services/logger_service.dart';
 import '../models/app_settings.dart';
-import '../services/logger_service.dart';
 import '../models/custom_list.dart';
-import '../services/logger_service.dart';
 
 /// ローカルストレージサービス（Hive使用）
 /// Todoをローカルに永続化し、オフラインファーストを実現
@@ -16,6 +13,7 @@ class LocalStorageService {
   static const String _onboardingCompletedKey = 'onboarding_completed';
   static const String _useAmberKey = 'use_amber';
   static const String _appSettingsKey = 'app_settings';
+  static const String _recurringTasksTipsDismissedKey = 'recurring_tasks_tips_dismissed';
   
   Box<Map>? _todosBox;
   Box? _settingsBox;
@@ -279,6 +277,24 @@ class LocalStorageService {
       AppLogger.warning(' アプリ設定復元エラー: $e');
       return null;
     }
+  }
+  
+  // === Recurring Tasks Tips関連 ===
+  
+  /// Recurring Tasks Tipsが表示済みかチェック
+  bool hasSeenRecurringTasksTips() {
+    if (_settingsBox == null) {
+      throw Exception('LocalStorageService not initialized');
+    }
+    return _settingsBox!.get(_recurringTasksTipsDismissedKey, defaultValue: false) as bool;
+  }
+  
+  /// Recurring Tasks Tipsを表示済みとしてマーク
+  Future<void> markRecurringTasksTipsAsSeen() async {
+    if (_settingsBox == null) {
+      throw Exception('LocalStorageService not initialized');
+    }
+    await _settingsBox!.put(_recurringTasksTipsDismissedKey, true);
   }
 }
 


### PR DESCRIPTION
## Changes
- Add recurring tasks tips UI on first task creation
- Tips shown only once with "Got it ✓" button
- TeuxDeux style colors (beige background)
- Fix onboarding screen pixel overflow

## Files
- `lib/presentation/onboarding/onboarding_screen.dart`
- `lib/services/local_storage_service.dart`
- `lib/widgets/todo_edit_screen.dart`