### PR TITLE
fix: #67 Support Android 13+ per-app language settings

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
         android:label="meiso"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        android:localeConfig="@xml/locales_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/locales_config.xml
+++ b/android/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en"/>
+    <locale android:name="ja"/>
+    <locale android:name="es"/>
+</locale-config>
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -258,6 +258,28 @@ class _MeisoAppState extends ConsumerState<MeisoApp> {
             Locale('es'), // Spanish
           ],
           locale: locale,
+          // Android 13+の「App languages」設定を優先的に反映
+          localeListResolutionCallback: (systemLocales, supportedLocales) {
+            // ユーザーが手動で言語を設定している場合はそれを優先
+            if (locale != null) {
+              return locale;
+            }
+            
+            // システムのロケールリスト（App languages設定を含む）から
+            // サポートしている言語を探す
+            if (systemLocales != null) {
+              for (final systemLocale in systemLocales) {
+                for (final supportedLocale in supportedLocales) {
+                  if (systemLocale.languageCode == supportedLocale.languageCode) {
+                    return supportedLocale;
+                  }
+                }
+              }
+            }
+            
+            // マッチする言語がない場合は英語をデフォルトとする
+            return const Locale('en');
+          },
         );
       },
       loading: () {
@@ -280,6 +302,23 @@ class _MeisoAppState extends ConsumerState<MeisoApp> {
             Locale('es'), // Spanish
           ],
           locale: locale,
+          localeListResolutionCallback: (systemLocales, supportedLocales) {
+            if (locale != null) {
+              return locale;
+            }
+            
+            if (systemLocales != null) {
+              for (final systemLocale in systemLocales) {
+                for (final supportedLocale in supportedLocales) {
+                  if (systemLocale.languageCode == supportedLocale.languageCode) {
+                    return supportedLocale;
+                  }
+                }
+              }
+            }
+            
+            return const Locale('en');
+          },
         );
       },
       error: (error, stack) {
@@ -302,6 +341,23 @@ class _MeisoAppState extends ConsumerState<MeisoApp> {
             Locale('es'), // Spanish
           ],
           locale: locale,
+          localeListResolutionCallback: (systemLocales, supportedLocales) {
+            if (locale != null) {
+              return locale;
+            }
+            
+            if (systemLocales != null) {
+              for (final systemLocale in systemLocales) {
+                for (final supportedLocale in supportedLocales) {
+                  if (systemLocale.languageCode == supportedLocale.languageCode) {
+                    return supportedLocale;
+                  }
+                }
+              }
+            }
+            
+            return const Locale('en');
+          },
         );
       },
     );


### PR DESCRIPTION
Add localeConfig to AndroidManifest.xml
Create locales_config.xml for supported locales (en, ja, es)
Implement localeListResolutionCallback in main.dart

Closes #67