### PR TITLE
feat(savings): savings custom list (Cashu × NutZap)

### DIFF
--- a/lib/features/savings/domain/entities/cashu_proof.dart
+++ b/lib/features/savings/domain/entities/cashu_proof.dart
@@ -1,0 +1,43 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'cashu_proof.freezed.dart';
+part 'cashu_proof.g.dart';
+
+/// Cashu の proof（ecash 本体）
+///
+/// ⚠️ これは **bearer 資産** である。secret を知る者が使用できる。
+/// 取り扱い注意:
+/// - secret / C をログに出力してはならない（[toString] でマスクする）
+/// - NIP-60 kind 7375 として暗号化保存する（平文でリレーに出さない）
+///
+/// フィールドは Cashu NUT-00 の Proof 形式に対応する。
+@freezed
+class CashuProof with _$CashuProof {
+  const factory CashuProof({
+    /// keyset ID（どの mint / keyset の proof か）
+    required String id,
+
+    /// 額面（sat）。Cashu は 2 の冪の額面に分割される。
+    required int amount,
+
+    /// 秘密値（この proof の所有を証明する）。**秘密**
+    required String secret,
+
+    /// 署名（unblinded signature, 16進）
+    required String C,
+
+    /// この proof を保管している mint の URL
+    required String mintUrl,
+  }) = _CashuProof;
+
+  const CashuProof._();
+
+  factory CashuProof.fromJson(Map<String, dynamic> json) =>
+      _$CashuProofFromJson(json);
+
+  /// 秘密値・署名をマスクしてログ事故を防ぐ
+  @override
+  String toString() =>
+      'CashuProof(id: $id, amount: $amount, mintUrl: $mintUrl, '
+      'secret: <redacted>, C: <redacted>)';
+}

--- a/lib/features/savings/domain/entities/cashu_proof.freezed.dart
+++ b/lib/features/savings/domain/entities/cashu_proof.freezed.dart
@@ -1,0 +1,270 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'cashu_proof.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+CashuProof _$CashuProofFromJson(Map<String, dynamic> json) {
+  return _CashuProof.fromJson(json);
+}
+
+/// @nodoc
+mixin _$CashuProof {
+  /// keyset ID（どの mint / keyset の proof か）
+  String get id => throw _privateConstructorUsedError;
+
+  /// 額面（sat）。Cashu は 2 の冪の額面に分割される。
+  int get amount => throw _privateConstructorUsedError;
+
+  /// 秘密値（この proof の所有を証明する）。**秘密**
+  String get secret => throw _privateConstructorUsedError;
+
+  /// 署名（unblinded signature, 16進）
+  String get C => throw _privateConstructorUsedError;
+
+  /// この proof を保管している mint の URL
+  String get mintUrl => throw _privateConstructorUsedError;
+
+  /// Serializes this CashuProof to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of CashuProof
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $CashuProofCopyWith<CashuProof> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $CashuProofCopyWith<$Res> {
+  factory $CashuProofCopyWith(
+    CashuProof value,
+    $Res Function(CashuProof) then,
+  ) = _$CashuProofCopyWithImpl<$Res, CashuProof>;
+  @useResult
+  $Res call({String id, int amount, String secret, String C, String mintUrl});
+}
+
+/// @nodoc
+class _$CashuProofCopyWithImpl<$Res, $Val extends CashuProof>
+    implements $CashuProofCopyWith<$Res> {
+  _$CashuProofCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of CashuProof
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? amount = null,
+    Object? secret = null,
+    Object? C = null,
+    Object? mintUrl = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            id: null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String,
+            amount: null == amount
+                ? _value.amount
+                : amount // ignore: cast_nullable_to_non_nullable
+                      as int,
+            secret: null == secret
+                ? _value.secret
+                : secret // ignore: cast_nullable_to_non_nullable
+                      as String,
+            C: null == C
+                ? _value.C
+                : C // ignore: cast_nullable_to_non_nullable
+                      as String,
+            mintUrl: null == mintUrl
+                ? _value.mintUrl
+                : mintUrl // ignore: cast_nullable_to_non_nullable
+                      as String,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$CashuProofImplCopyWith<$Res>
+    implements $CashuProofCopyWith<$Res> {
+  factory _$$CashuProofImplCopyWith(
+    _$CashuProofImpl value,
+    $Res Function(_$CashuProofImpl) then,
+  ) = __$$CashuProofImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String id, int amount, String secret, String C, String mintUrl});
+}
+
+/// @nodoc
+class __$$CashuProofImplCopyWithImpl<$Res>
+    extends _$CashuProofCopyWithImpl<$Res, _$CashuProofImpl>
+    implements _$$CashuProofImplCopyWith<$Res> {
+  __$$CashuProofImplCopyWithImpl(
+    _$CashuProofImpl _value,
+    $Res Function(_$CashuProofImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of CashuProof
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? amount = null,
+    Object? secret = null,
+    Object? C = null,
+    Object? mintUrl = null,
+  }) {
+    return _then(
+      _$CashuProofImpl(
+        id: null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+        amount: null == amount
+            ? _value.amount
+            : amount // ignore: cast_nullable_to_non_nullable
+                  as int,
+        secret: null == secret
+            ? _value.secret
+            : secret // ignore: cast_nullable_to_non_nullable
+                  as String,
+        C: null == C
+            ? _value.C
+            : C // ignore: cast_nullable_to_non_nullable
+                  as String,
+        mintUrl: null == mintUrl
+            ? _value.mintUrl
+            : mintUrl // ignore: cast_nullable_to_non_nullable
+                  as String,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$CashuProofImpl extends _CashuProof {
+  const _$CashuProofImpl({
+    required this.id,
+    required this.amount,
+    required this.secret,
+    required this.C,
+    required this.mintUrl,
+  }) : super._();
+
+  factory _$CashuProofImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CashuProofImplFromJson(json);
+
+  /// keyset ID（どの mint / keyset の proof か）
+  @override
+  final String id;
+
+  /// 額面（sat）。Cashu は 2 の冪の額面に分割される。
+  @override
+  final int amount;
+
+  /// 秘密値（この proof の所有を証明する）。**秘密**
+  @override
+  final String secret;
+
+  /// 署名（unblinded signature, 16進）
+  @override
+  final String C;
+
+  /// この proof を保管している mint の URL
+  @override
+  final String mintUrl;
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$CashuProofImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.amount, amount) || other.amount == amount) &&
+            (identical(other.secret, secret) || other.secret == secret) &&
+            (identical(other.C, C) || other.C == C) &&
+            (identical(other.mintUrl, mintUrl) || other.mintUrl == mintUrl));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, amount, secret, C, mintUrl);
+
+  /// Create a copy of CashuProof
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$CashuProofImplCopyWith<_$CashuProofImpl> get copyWith =>
+      __$$CashuProofImplCopyWithImpl<_$CashuProofImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$CashuProofImplToJson(this);
+  }
+}
+
+abstract class _CashuProof extends CashuProof {
+  const factory _CashuProof({
+    required final String id,
+    required final int amount,
+    required final String secret,
+    required final String C,
+    required final String mintUrl,
+  }) = _$CashuProofImpl;
+  const _CashuProof._() : super._();
+
+  factory _CashuProof.fromJson(Map<String, dynamic> json) =
+      _$CashuProofImpl.fromJson;
+
+  /// keyset ID（どの mint / keyset の proof か）
+  @override
+  String get id;
+
+  /// 額面（sat）。Cashu は 2 の冪の額面に分割される。
+  @override
+  int get amount;
+
+  /// 秘密値（この proof の所有を証明する）。**秘密**
+  @override
+  String get secret;
+
+  /// 署名（unblinded signature, 16進）
+  @override
+  String get C;
+
+  /// この proof を保管している mint の URL
+  @override
+  String get mintUrl;
+
+  /// Create a copy of CashuProof
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$CashuProofImplCopyWith<_$CashuProofImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/savings/domain/entities/cashu_proof.g.dart
+++ b/lib/features/savings/domain/entities/cashu_proof.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cashu_proof.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$CashuProofImpl _$$CashuProofImplFromJson(Map<String, dynamic> json) =>
+    _$CashuProofImpl(
+      id: json['id'] as String,
+      amount: (json['amount'] as num).toInt(),
+      secret: json['secret'] as String,
+      C: json['C'] as String,
+      mintUrl: json['mintUrl'] as String,
+    );
+
+Map<String, dynamic> _$$CashuProofImplToJson(_$CashuProofImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'amount': instance.amount,
+      'secret': instance.secret,
+      'C': instance.C,
+      'mintUrl': instance.mintUrl,
+    };

--- a/lib/features/savings/domain/entities/goal_balance.dart
+++ b/lib/features/savings/domain/entities/goal_balance.dart
@@ -1,0 +1,51 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'goal_balance.freezed.dart';
+part 'goal_balance.g.dart';
+
+/// 貯金ゴールの残高・進捗
+///
+/// ゴールウォレットの未使用 proof 合計（[currentSats]）と目標額
+/// （[targetSats]）から進捗を算出する。表示用の派生値を提供する。
+@freezed
+class GoalBalance with _$GoalBalance {
+  const factory GoalBalance({
+    /// 対象ゴールID
+    required String goalId,
+
+    /// 現在の貯金額（未使用 proof 合計, sat）
+    required int currentSats,
+
+    /// 目標額（sat）
+    required int targetSats,
+  }) = _GoalBalance;
+
+  const GoalBalance._();
+
+  factory GoalBalance.fromJson(Map<String, dynamic> json) =>
+      _$GoalBalanceFromJson(json);
+
+  /// 進捗率（0.0〜1.0）。targetSats が 0 以下なら 0。
+  double get progress {
+    if (targetSats <= 0) {
+      return 0;
+    }
+    final p = currentSats / targetSats;
+    if (p < 0) {
+      return 0;
+    }
+    if (p > 1) {
+      return 1;
+    }
+    return p;
+  }
+
+  /// 目標達成済みか
+  bool get isReached => targetSats > 0 && currentSats >= targetSats;
+
+  /// 目標までの残額（sat, 0 未満にはならない）
+  int get remainingSats {
+    final r = targetSats - currentSats;
+    return r < 0 ? 0 : r;
+  }
+}

--- a/lib/features/savings/domain/entities/goal_balance.freezed.dart
+++ b/lib/features/savings/domain/entities/goal_balance.freezed.dart
@@ -1,0 +1,229 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'goal_balance.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+GoalBalance _$GoalBalanceFromJson(Map<String, dynamic> json) {
+  return _GoalBalance.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GoalBalance {
+  /// 対象ゴールID
+  String get goalId => throw _privateConstructorUsedError;
+
+  /// 現在の貯金額（未使用 proof 合計, sat）
+  int get currentSats => throw _privateConstructorUsedError;
+
+  /// 目標額（sat）
+  int get targetSats => throw _privateConstructorUsedError;
+
+  /// Serializes this GoalBalance to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of GoalBalance
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $GoalBalanceCopyWith<GoalBalance> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GoalBalanceCopyWith<$Res> {
+  factory $GoalBalanceCopyWith(
+    GoalBalance value,
+    $Res Function(GoalBalance) then,
+  ) = _$GoalBalanceCopyWithImpl<$Res, GoalBalance>;
+  @useResult
+  $Res call({String goalId, int currentSats, int targetSats});
+}
+
+/// @nodoc
+class _$GoalBalanceCopyWithImpl<$Res, $Val extends GoalBalance>
+    implements $GoalBalanceCopyWith<$Res> {
+  _$GoalBalanceCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of GoalBalance
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? goalId = null,
+    Object? currentSats = null,
+    Object? targetSats = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            goalId: null == goalId
+                ? _value.goalId
+                : goalId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            currentSats: null == currentSats
+                ? _value.currentSats
+                : currentSats // ignore: cast_nullable_to_non_nullable
+                      as int,
+            targetSats: null == targetSats
+                ? _value.targetSats
+                : targetSats // ignore: cast_nullable_to_non_nullable
+                      as int,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$GoalBalanceImplCopyWith<$Res>
+    implements $GoalBalanceCopyWith<$Res> {
+  factory _$$GoalBalanceImplCopyWith(
+    _$GoalBalanceImpl value,
+    $Res Function(_$GoalBalanceImpl) then,
+  ) = __$$GoalBalanceImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String goalId, int currentSats, int targetSats});
+}
+
+/// @nodoc
+class __$$GoalBalanceImplCopyWithImpl<$Res>
+    extends _$GoalBalanceCopyWithImpl<$Res, _$GoalBalanceImpl>
+    implements _$$GoalBalanceImplCopyWith<$Res> {
+  __$$GoalBalanceImplCopyWithImpl(
+    _$GoalBalanceImpl _value,
+    $Res Function(_$GoalBalanceImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of GoalBalance
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? goalId = null,
+    Object? currentSats = null,
+    Object? targetSats = null,
+  }) {
+    return _then(
+      _$GoalBalanceImpl(
+        goalId: null == goalId
+            ? _value.goalId
+            : goalId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        currentSats: null == currentSats
+            ? _value.currentSats
+            : currentSats // ignore: cast_nullable_to_non_nullable
+                  as int,
+        targetSats: null == targetSats
+            ? _value.targetSats
+            : targetSats // ignore: cast_nullable_to_non_nullable
+                  as int,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$GoalBalanceImpl extends _GoalBalance {
+  const _$GoalBalanceImpl({
+    required this.goalId,
+    required this.currentSats,
+    required this.targetSats,
+  }) : super._();
+
+  factory _$GoalBalanceImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GoalBalanceImplFromJson(json);
+
+  /// 対象ゴールID
+  @override
+  final String goalId;
+
+  /// 現在の貯金額（未使用 proof 合計, sat）
+  @override
+  final int currentSats;
+
+  /// 目標額（sat）
+  @override
+  final int targetSats;
+
+  @override
+  String toString() {
+    return 'GoalBalance(goalId: $goalId, currentSats: $currentSats, targetSats: $targetSats)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GoalBalanceImpl &&
+            (identical(other.goalId, goalId) || other.goalId == goalId) &&
+            (identical(other.currentSats, currentSats) ||
+                other.currentSats == currentSats) &&
+            (identical(other.targetSats, targetSats) ||
+                other.targetSats == targetSats));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, goalId, currentSats, targetSats);
+
+  /// Create a copy of GoalBalance
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GoalBalanceImplCopyWith<_$GoalBalanceImpl> get copyWith =>
+      __$$GoalBalanceImplCopyWithImpl<_$GoalBalanceImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$GoalBalanceImplToJson(this);
+  }
+}
+
+abstract class _GoalBalance extends GoalBalance {
+  const factory _GoalBalance({
+    required final String goalId,
+    required final int currentSats,
+    required final int targetSats,
+  }) = _$GoalBalanceImpl;
+  const _GoalBalance._() : super._();
+
+  factory _GoalBalance.fromJson(Map<String, dynamic> json) =
+      _$GoalBalanceImpl.fromJson;
+
+  /// 対象ゴールID
+  @override
+  String get goalId;
+
+  /// 現在の貯金額（未使用 proof 合計, sat）
+  @override
+  int get currentSats;
+
+  /// 目標額（sat）
+  @override
+  int get targetSats;
+
+  /// Create a copy of GoalBalance
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$GoalBalanceImplCopyWith<_$GoalBalanceImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/savings/domain/entities/goal_balance.g.dart
+++ b/lib/features/savings/domain/entities/goal_balance.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'goal_balance.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$GoalBalanceImpl _$$GoalBalanceImplFromJson(Map<String, dynamic> json) =>
+    _$GoalBalanceImpl(
+      goalId: json['goalId'] as String,
+      currentSats: (json['currentSats'] as num).toInt(),
+      targetSats: (json['targetSats'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$GoalBalanceImplToJson(_$GoalBalanceImpl instance) =>
+    <String, dynamic>{
+      'goalId': instance.goalId,
+      'currentSats': instance.currentSats,
+      'targetSats': instance.targetSats,
+    };

--- a/lib/features/savings/domain/entities/nutzap_contribution.dart
+++ b/lib/features/savings/domain/entities/nutzap_contribution.dart
@@ -1,0 +1,34 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'nutzap_contribution.freezed.dart';
+part 'nutzap_contribution.g.dart';
+
+/// 受け取った NutZap（協同貯金への貢献）
+///
+/// NIP-61 の kind 9321 NutZap を回収（swap）した結果の記録。
+/// コントリビューションフィードや「誰がいくら投げたか」の表示に使う。
+@freezed
+class NutzapContribution with _$NutzapContribution {
+  const factory NutzapContribution({
+    /// 元となった kind 9321 イベントID（重複回収防止のキー）
+    required String eventId,
+
+    /// 貢献先ゴールID
+    required String goalId,
+
+    /// 額面（sat）
+    required int amountSats,
+
+    /// 送り主の公開鍵（hex）
+    required String senderPubkey,
+
+    /// 任意のメッセージ（NutZap の content）
+    String? comment,
+
+    /// 回収（自分のウォレットへ swap）した日時
+    required DateTime redeemedAt,
+  }) = _NutzapContribution;
+
+  factory NutzapContribution.fromJson(Map<String, dynamic> json) =>
+      _$NutzapContributionFromJson(json);
+}

--- a/lib/features/savings/domain/entities/nutzap_contribution.freezed.dart
+++ b/lib/features/savings/domain/entities/nutzap_contribution.freezed.dart
@@ -1,0 +1,326 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'nutzap_contribution.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+NutzapContribution _$NutzapContributionFromJson(Map<String, dynamic> json) {
+  return _NutzapContribution.fromJson(json);
+}
+
+/// @nodoc
+mixin _$NutzapContribution {
+  /// 元となった kind 9321 イベントID（重複回収防止のキー）
+  String get eventId => throw _privateConstructorUsedError;
+
+  /// 貢献先ゴールID
+  String get goalId => throw _privateConstructorUsedError;
+
+  /// 額面（sat）
+  int get amountSats => throw _privateConstructorUsedError;
+
+  /// 送り主の公開鍵（hex）
+  String get senderPubkey => throw _privateConstructorUsedError;
+
+  /// 任意のメッセージ（NutZap の content）
+  String? get comment => throw _privateConstructorUsedError;
+
+  /// 回収（自分のウォレットへ swap）した日時
+  DateTime get redeemedAt => throw _privateConstructorUsedError;
+
+  /// Serializes this NutzapContribution to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of NutzapContribution
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $NutzapContributionCopyWith<NutzapContribution> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $NutzapContributionCopyWith<$Res> {
+  factory $NutzapContributionCopyWith(
+    NutzapContribution value,
+    $Res Function(NutzapContribution) then,
+  ) = _$NutzapContributionCopyWithImpl<$Res, NutzapContribution>;
+  @useResult
+  $Res call({
+    String eventId,
+    String goalId,
+    int amountSats,
+    String senderPubkey,
+    String? comment,
+    DateTime redeemedAt,
+  });
+}
+
+/// @nodoc
+class _$NutzapContributionCopyWithImpl<$Res, $Val extends NutzapContribution>
+    implements $NutzapContributionCopyWith<$Res> {
+  _$NutzapContributionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of NutzapContribution
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? eventId = null,
+    Object? goalId = null,
+    Object? amountSats = null,
+    Object? senderPubkey = null,
+    Object? comment = freezed,
+    Object? redeemedAt = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            eventId: null == eventId
+                ? _value.eventId
+                : eventId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            goalId: null == goalId
+                ? _value.goalId
+                : goalId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            amountSats: null == amountSats
+                ? _value.amountSats
+                : amountSats // ignore: cast_nullable_to_non_nullable
+                      as int,
+            senderPubkey: null == senderPubkey
+                ? _value.senderPubkey
+                : senderPubkey // ignore: cast_nullable_to_non_nullable
+                      as String,
+            comment: freezed == comment
+                ? _value.comment
+                : comment // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            redeemedAt: null == redeemedAt
+                ? _value.redeemedAt
+                : redeemedAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$NutzapContributionImplCopyWith<$Res>
+    implements $NutzapContributionCopyWith<$Res> {
+  factory _$$NutzapContributionImplCopyWith(
+    _$NutzapContributionImpl value,
+    $Res Function(_$NutzapContributionImpl) then,
+  ) = __$$NutzapContributionImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String eventId,
+    String goalId,
+    int amountSats,
+    String senderPubkey,
+    String? comment,
+    DateTime redeemedAt,
+  });
+}
+
+/// @nodoc
+class __$$NutzapContributionImplCopyWithImpl<$Res>
+    extends _$NutzapContributionCopyWithImpl<$Res, _$NutzapContributionImpl>
+    implements _$$NutzapContributionImplCopyWith<$Res> {
+  __$$NutzapContributionImplCopyWithImpl(
+    _$NutzapContributionImpl _value,
+    $Res Function(_$NutzapContributionImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of NutzapContribution
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? eventId = null,
+    Object? goalId = null,
+    Object? amountSats = null,
+    Object? senderPubkey = null,
+    Object? comment = freezed,
+    Object? redeemedAt = null,
+  }) {
+    return _then(
+      _$NutzapContributionImpl(
+        eventId: null == eventId
+            ? _value.eventId
+            : eventId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        goalId: null == goalId
+            ? _value.goalId
+            : goalId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        amountSats: null == amountSats
+            ? _value.amountSats
+            : amountSats // ignore: cast_nullable_to_non_nullable
+                  as int,
+        senderPubkey: null == senderPubkey
+            ? _value.senderPubkey
+            : senderPubkey // ignore: cast_nullable_to_non_nullable
+                  as String,
+        comment: freezed == comment
+            ? _value.comment
+            : comment // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        redeemedAt: null == redeemedAt
+            ? _value.redeemedAt
+            : redeemedAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$NutzapContributionImpl implements _NutzapContribution {
+  const _$NutzapContributionImpl({
+    required this.eventId,
+    required this.goalId,
+    required this.amountSats,
+    required this.senderPubkey,
+    this.comment,
+    required this.redeemedAt,
+  });
+
+  factory _$NutzapContributionImpl.fromJson(Map<String, dynamic> json) =>
+      _$$NutzapContributionImplFromJson(json);
+
+  /// 元となった kind 9321 イベントID（重複回収防止のキー）
+  @override
+  final String eventId;
+
+  /// 貢献先ゴールID
+  @override
+  final String goalId;
+
+  /// 額面（sat）
+  @override
+  final int amountSats;
+
+  /// 送り主の公開鍵（hex）
+  @override
+  final String senderPubkey;
+
+  /// 任意のメッセージ（NutZap の content）
+  @override
+  final String? comment;
+
+  /// 回収（自分のウォレットへ swap）した日時
+  @override
+  final DateTime redeemedAt;
+
+  @override
+  String toString() {
+    return 'NutzapContribution(eventId: $eventId, goalId: $goalId, amountSats: $amountSats, senderPubkey: $senderPubkey, comment: $comment, redeemedAt: $redeemedAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$NutzapContributionImpl &&
+            (identical(other.eventId, eventId) || other.eventId == eventId) &&
+            (identical(other.goalId, goalId) || other.goalId == goalId) &&
+            (identical(other.amountSats, amountSats) ||
+                other.amountSats == amountSats) &&
+            (identical(other.senderPubkey, senderPubkey) ||
+                other.senderPubkey == senderPubkey) &&
+            (identical(other.comment, comment) || other.comment == comment) &&
+            (identical(other.redeemedAt, redeemedAt) ||
+                other.redeemedAt == redeemedAt));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    eventId,
+    goalId,
+    amountSats,
+    senderPubkey,
+    comment,
+    redeemedAt,
+  );
+
+  /// Create a copy of NutzapContribution
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$NutzapContributionImplCopyWith<_$NutzapContributionImpl> get copyWith =>
+      __$$NutzapContributionImplCopyWithImpl<_$NutzapContributionImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$NutzapContributionImplToJson(this);
+  }
+}
+
+abstract class _NutzapContribution implements NutzapContribution {
+  const factory _NutzapContribution({
+    required final String eventId,
+    required final String goalId,
+    required final int amountSats,
+    required final String senderPubkey,
+    final String? comment,
+    required final DateTime redeemedAt,
+  }) = _$NutzapContributionImpl;
+
+  factory _NutzapContribution.fromJson(Map<String, dynamic> json) =
+      _$NutzapContributionImpl.fromJson;
+
+  /// 元となった kind 9321 イベントID（重複回収防止のキー）
+  @override
+  String get eventId;
+
+  /// 貢献先ゴールID
+  @override
+  String get goalId;
+
+  /// 額面（sat）
+  @override
+  int get amountSats;
+
+  /// 送り主の公開鍵（hex）
+  @override
+  String get senderPubkey;
+
+  /// 任意のメッセージ（NutZap の content）
+  @override
+  String? get comment;
+
+  /// 回収（自分のウォレットへ swap）した日時
+  @override
+  DateTime get redeemedAt;
+
+  /// Create a copy of NutzapContribution
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$NutzapContributionImplCopyWith<_$NutzapContributionImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/savings/domain/entities/nutzap_contribution.g.dart
+++ b/lib/features/savings/domain/entities/nutzap_contribution.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'nutzap_contribution.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$NutzapContributionImpl _$$NutzapContributionImplFromJson(
+  Map<String, dynamic> json,
+) => _$NutzapContributionImpl(
+  eventId: json['eventId'] as String,
+  goalId: json['goalId'] as String,
+  amountSats: (json['amountSats'] as num).toInt(),
+  senderPubkey: json['senderPubkey'] as String,
+  comment: json['comment'] as String?,
+  redeemedAt: DateTime.parse(json['redeemedAt'] as String),
+);
+
+Map<String, dynamic> _$$NutzapContributionImplToJson(
+  _$NutzapContributionImpl instance,
+) => <String, dynamic>{
+  'eventId': instance.eventId,
+  'goalId': instance.goalId,
+  'amountSats': instance.amountSats,
+  'senderPubkey': instance.senderPubkey,
+  'comment': instance.comment,
+  'redeemedAt': instance.redeemedAt.toIso8601String(),
+};

--- a/lib/features/savings/domain/entities/savings_goal.dart
+++ b/lib/features/savings/domain/entities/savings_goal.dart
@@ -1,0 +1,71 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'savings_goal.freezed.dart';
+part 'savings_goal.g.dart';
+
+/// 貯金ゴール（貯金カスタムリストのメタデータ）
+///
+/// CustomList（Kind 30001）に「お金」を乗せるための種別メタ。
+/// 個人積立・共同貯金の両方を表現する。
+///
+/// 設計方針（壁打ちで確定）:
+/// - 単位は sat 固定（[targetSats] / [currency]）
+/// - mint は非依存に持つ（[mintUrl]）。MVPは単一 mint だが将来複数化できる形
+/// - ロックは UX ロック（P2PK locktime は使わない）。[deadline] と達成判定で
+///   引き出しボタンの表示可否を制御する
+/// - [isCollaborative] が true のとき、[p2pkPubkey] を NIP-61 kind 10019 で
+///   公開し、他者の NutZap（kind 9321）を受け取る
+@freezed
+class SavingsGoal with _$SavingsGoal {
+  const factory SavingsGoal({
+    /// ゴールID（CustomList.id と対応。決定的に生成）
+    required String goalId,
+
+    /// ゴール名（表示用）
+    required String name,
+
+    /// 目標額（sat）
+    required int targetSats,
+
+    /// このゴールが ecash を保管する mint の URL
+    required String mintUrl,
+
+    /// 受取用 P2PK 公開鍵（hex）。
+    /// 協同ゴールで NutZap を受け取る場合のみ必須。個人積立では null 可。
+    String? p2pkPubkey,
+
+    /// 引き出し解禁の目安期日（UX ロック用）。null なら期日条件なし。
+    DateTime? deadline,
+
+    /// 協同（共同貯金）かどうか。
+    /// true のとき kind 10019 を公開し、メンバー/他者の NutZap を受け付ける。
+    @Default(false) bool isCollaborative,
+
+    /// 作成日時
+    required DateTime createdAt,
+
+    /// 単位通貨（現状 'sat' 固定。将来拡張用）
+    @Default('sat') String currency,
+  }) = _SavingsGoal;
+
+  factory SavingsGoal.fromJson(Map<String, dynamic> json) =>
+      _$SavingsGoalFromJson(json);
+}
+
+/// SavingsGoal のヘルパー
+extension SavingsGoalHelpers on SavingsGoal {
+  /// Nostr の d タグに使うプレフィックス（ゴール定義 Kind 30001）
+  static const String dTagPrefix = 'meiso-savings-';
+
+  /// ゴールIDから Nostr d タグを生成する
+  String get dTag => '$dTagPrefix$goalId';
+
+  /// 期日を過ぎているか（UX ロック判定に使用）
+  bool isPastDeadline(DateTime now) {
+    final d = deadline;
+    if (d == null) {
+      return false;
+    }
+    return now.isAfter(d);
+  }
+}

--- a/lib/features/savings/domain/entities/savings_goal.freezed.dart
+++ b/lib/features/savings/domain/entities/savings_goal.freezed.dart
@@ -1,0 +1,415 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'savings_goal.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+SavingsGoal _$SavingsGoalFromJson(Map<String, dynamic> json) {
+  return _SavingsGoal.fromJson(json);
+}
+
+/// @nodoc
+mixin _$SavingsGoal {
+  /// ゴールID（CustomList.id と対応。決定的に生成）
+  String get goalId => throw _privateConstructorUsedError;
+
+  /// ゴール名（表示用）
+  String get name => throw _privateConstructorUsedError;
+
+  /// 目標額（sat）
+  int get targetSats => throw _privateConstructorUsedError;
+
+  /// このゴールが ecash を保管する mint の URL
+  String get mintUrl => throw _privateConstructorUsedError;
+
+  /// 受取用 P2PK 公開鍵（hex）。
+  /// 協同ゴールで NutZap を受け取る場合のみ必須。個人積立では null 可。
+  String? get p2pkPubkey => throw _privateConstructorUsedError;
+
+  /// 引き出し解禁の目安期日（UX ロック用）。null なら期日条件なし。
+  DateTime? get deadline => throw _privateConstructorUsedError;
+
+  /// 協同（共同貯金）かどうか。
+  /// true のとき kind 10019 を公開し、メンバー/他者の NutZap を受け付ける。
+  bool get isCollaborative => throw _privateConstructorUsedError;
+
+  /// 作成日時
+  DateTime get createdAt => throw _privateConstructorUsedError;
+
+  /// 単位通貨（現状 'sat' 固定。将来拡張用）
+  String get currency => throw _privateConstructorUsedError;
+
+  /// Serializes this SavingsGoal to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of SavingsGoal
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $SavingsGoalCopyWith<SavingsGoal> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SavingsGoalCopyWith<$Res> {
+  factory $SavingsGoalCopyWith(
+    SavingsGoal value,
+    $Res Function(SavingsGoal) then,
+  ) = _$SavingsGoalCopyWithImpl<$Res, SavingsGoal>;
+  @useResult
+  $Res call({
+    String goalId,
+    String name,
+    int targetSats,
+    String mintUrl,
+    String? p2pkPubkey,
+    DateTime? deadline,
+    bool isCollaborative,
+    DateTime createdAt,
+    String currency,
+  });
+}
+
+/// @nodoc
+class _$SavingsGoalCopyWithImpl<$Res, $Val extends SavingsGoal>
+    implements $SavingsGoalCopyWith<$Res> {
+  _$SavingsGoalCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of SavingsGoal
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? goalId = null,
+    Object? name = null,
+    Object? targetSats = null,
+    Object? mintUrl = null,
+    Object? p2pkPubkey = freezed,
+    Object? deadline = freezed,
+    Object? isCollaborative = null,
+    Object? createdAt = null,
+    Object? currency = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            goalId: null == goalId
+                ? _value.goalId
+                : goalId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            name: null == name
+                ? _value.name
+                : name // ignore: cast_nullable_to_non_nullable
+                      as String,
+            targetSats: null == targetSats
+                ? _value.targetSats
+                : targetSats // ignore: cast_nullable_to_non_nullable
+                      as int,
+            mintUrl: null == mintUrl
+                ? _value.mintUrl
+                : mintUrl // ignore: cast_nullable_to_non_nullable
+                      as String,
+            p2pkPubkey: freezed == p2pkPubkey
+                ? _value.p2pkPubkey
+                : p2pkPubkey // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            deadline: freezed == deadline
+                ? _value.deadline
+                : deadline // ignore: cast_nullable_to_non_nullable
+                      as DateTime?,
+            isCollaborative: null == isCollaborative
+                ? _value.isCollaborative
+                : isCollaborative // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            createdAt: null == createdAt
+                ? _value.createdAt
+                : createdAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            currency: null == currency
+                ? _value.currency
+                : currency // ignore: cast_nullable_to_non_nullable
+                      as String,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$SavingsGoalImplCopyWith<$Res>
+    implements $SavingsGoalCopyWith<$Res> {
+  factory _$$SavingsGoalImplCopyWith(
+    _$SavingsGoalImpl value,
+    $Res Function(_$SavingsGoalImpl) then,
+  ) = __$$SavingsGoalImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String goalId,
+    String name,
+    int targetSats,
+    String mintUrl,
+    String? p2pkPubkey,
+    DateTime? deadline,
+    bool isCollaborative,
+    DateTime createdAt,
+    String currency,
+  });
+}
+
+/// @nodoc
+class __$$SavingsGoalImplCopyWithImpl<$Res>
+    extends _$SavingsGoalCopyWithImpl<$Res, _$SavingsGoalImpl>
+    implements _$$SavingsGoalImplCopyWith<$Res> {
+  __$$SavingsGoalImplCopyWithImpl(
+    _$SavingsGoalImpl _value,
+    $Res Function(_$SavingsGoalImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of SavingsGoal
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? goalId = null,
+    Object? name = null,
+    Object? targetSats = null,
+    Object? mintUrl = null,
+    Object? p2pkPubkey = freezed,
+    Object? deadline = freezed,
+    Object? isCollaborative = null,
+    Object? createdAt = null,
+    Object? currency = null,
+  }) {
+    return _then(
+      _$SavingsGoalImpl(
+        goalId: null == goalId
+            ? _value.goalId
+            : goalId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        name: null == name
+            ? _value.name
+            : name // ignore: cast_nullable_to_non_nullable
+                  as String,
+        targetSats: null == targetSats
+            ? _value.targetSats
+            : targetSats // ignore: cast_nullable_to_non_nullable
+                  as int,
+        mintUrl: null == mintUrl
+            ? _value.mintUrl
+            : mintUrl // ignore: cast_nullable_to_non_nullable
+                  as String,
+        p2pkPubkey: freezed == p2pkPubkey
+            ? _value.p2pkPubkey
+            : p2pkPubkey // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        deadline: freezed == deadline
+            ? _value.deadline
+            : deadline // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+        isCollaborative: null == isCollaborative
+            ? _value.isCollaborative
+            : isCollaborative // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        createdAt: null == createdAt
+            ? _value.createdAt
+            : createdAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        currency: null == currency
+            ? _value.currency
+            : currency // ignore: cast_nullable_to_non_nullable
+                  as String,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$SavingsGoalImpl implements _SavingsGoal {
+  const _$SavingsGoalImpl({
+    required this.goalId,
+    required this.name,
+    required this.targetSats,
+    required this.mintUrl,
+    this.p2pkPubkey,
+    this.deadline,
+    this.isCollaborative = false,
+    required this.createdAt,
+    this.currency = 'sat',
+  });
+
+  factory _$SavingsGoalImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SavingsGoalImplFromJson(json);
+
+  /// ゴールID（CustomList.id と対応。決定的に生成）
+  @override
+  final String goalId;
+
+  /// ゴール名（表示用）
+  @override
+  final String name;
+
+  /// 目標額（sat）
+  @override
+  final int targetSats;
+
+  /// このゴールが ecash を保管する mint の URL
+  @override
+  final String mintUrl;
+
+  /// 受取用 P2PK 公開鍵（hex）。
+  /// 協同ゴールで NutZap を受け取る場合のみ必須。個人積立では null 可。
+  @override
+  final String? p2pkPubkey;
+
+  /// 引き出し解禁の目安期日（UX ロック用）。null なら期日条件なし。
+  @override
+  final DateTime? deadline;
+
+  /// 協同（共同貯金）かどうか。
+  /// true のとき kind 10019 を公開し、メンバー/他者の NutZap を受け付ける。
+  @override
+  @JsonKey()
+  final bool isCollaborative;
+
+  /// 作成日時
+  @override
+  final DateTime createdAt;
+
+  /// 単位通貨（現状 'sat' 固定。将来拡張用）
+  @override
+  @JsonKey()
+  final String currency;
+
+  @override
+  String toString() {
+    return 'SavingsGoal(goalId: $goalId, name: $name, targetSats: $targetSats, mintUrl: $mintUrl, p2pkPubkey: $p2pkPubkey, deadline: $deadline, isCollaborative: $isCollaborative, createdAt: $createdAt, currency: $currency)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SavingsGoalImpl &&
+            (identical(other.goalId, goalId) || other.goalId == goalId) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.targetSats, targetSats) ||
+                other.targetSats == targetSats) &&
+            (identical(other.mintUrl, mintUrl) || other.mintUrl == mintUrl) &&
+            (identical(other.p2pkPubkey, p2pkPubkey) ||
+                other.p2pkPubkey == p2pkPubkey) &&
+            (identical(other.deadline, deadline) ||
+                other.deadline == deadline) &&
+            (identical(other.isCollaborative, isCollaborative) ||
+                other.isCollaborative == isCollaborative) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.currency, currency) ||
+                other.currency == currency));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    goalId,
+    name,
+    targetSats,
+    mintUrl,
+    p2pkPubkey,
+    deadline,
+    isCollaborative,
+    createdAt,
+    currency,
+  );
+
+  /// Create a copy of SavingsGoal
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SavingsGoalImplCopyWith<_$SavingsGoalImpl> get copyWith =>
+      __$$SavingsGoalImplCopyWithImpl<_$SavingsGoalImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SavingsGoalImplToJson(this);
+  }
+}
+
+abstract class _SavingsGoal implements SavingsGoal {
+  const factory _SavingsGoal({
+    required final String goalId,
+    required final String name,
+    required final int targetSats,
+    required final String mintUrl,
+    final String? p2pkPubkey,
+    final DateTime? deadline,
+    final bool isCollaborative,
+    required final DateTime createdAt,
+    final String currency,
+  }) = _$SavingsGoalImpl;
+
+  factory _SavingsGoal.fromJson(Map<String, dynamic> json) =
+      _$SavingsGoalImpl.fromJson;
+
+  /// ゴールID（CustomList.id と対応。決定的に生成）
+  @override
+  String get goalId;
+
+  /// ゴール名（表示用）
+  @override
+  String get name;
+
+  /// 目標額（sat）
+  @override
+  int get targetSats;
+
+  /// このゴールが ecash を保管する mint の URL
+  @override
+  String get mintUrl;
+
+  /// 受取用 P2PK 公開鍵（hex）。
+  /// 協同ゴールで NutZap を受け取る場合のみ必須。個人積立では null 可。
+  @override
+  String? get p2pkPubkey;
+
+  /// 引き出し解禁の目安期日（UX ロック用）。null なら期日条件なし。
+  @override
+  DateTime? get deadline;
+
+  /// 協同（共同貯金）かどうか。
+  /// true のとき kind 10019 を公開し、メンバー/他者の NutZap を受け付ける。
+  @override
+  bool get isCollaborative;
+
+  /// 作成日時
+  @override
+  DateTime get createdAt;
+
+  /// 単位通貨（現状 'sat' 固定。将来拡張用）
+  @override
+  String get currency;
+
+  /// Create a copy of SavingsGoal
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SavingsGoalImplCopyWith<_$SavingsGoalImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/savings/domain/entities/savings_goal.g.dart
+++ b/lib/features/savings/domain/entities/savings_goal.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'savings_goal.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$SavingsGoalImpl _$$SavingsGoalImplFromJson(Map<String, dynamic> json) =>
+    _$SavingsGoalImpl(
+      goalId: json['goalId'] as String,
+      name: json['name'] as String,
+      targetSats: (json['targetSats'] as num).toInt(),
+      mintUrl: json['mintUrl'] as String,
+      p2pkPubkey: json['p2pkPubkey'] as String?,
+      deadline: json['deadline'] == null
+          ? null
+          : DateTime.parse(json['deadline'] as String),
+      isCollaborative: json['isCollaborative'] as bool? ?? false,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      currency: json['currency'] as String? ?? 'sat',
+    );
+
+Map<String, dynamic> _$$SavingsGoalImplToJson(_$SavingsGoalImpl instance) =>
+    <String, dynamic>{
+      'goalId': instance.goalId,
+      'name': instance.name,
+      'targetSats': instance.targetSats,
+      'mintUrl': instance.mintUrl,
+      'p2pkPubkey': instance.p2pkPubkey,
+      'deadline': instance.deadline?.toIso8601String(),
+      'isCollaborative': instance.isCollaborative,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'currency': instance.currency,
+    };

--- a/lib/features/savings/domain/errors/savings_errors.dart
+++ b/lib/features/savings/domain/errors/savings_errors.dart
@@ -1,0 +1,84 @@
+import '../../../../core/common/failure.dart';
+
+/// 貯金（Cashu / NutZap）機能固有のエラー種別
+enum SavingsError {
+  /// mint に到達できない / 応答しない
+  mintUnreachable,
+
+  /// mint が要求を拒否した（額面不一致・無効 proof 等）
+  mintRejected,
+
+  /// proof が不足している（残高不足）
+  insufficientProofs,
+
+  /// NutZap の回収（swap）に失敗
+  redeemFailed,
+
+  /// ウォレット状態（NIP-60）の同期に失敗
+  walletSyncFailed,
+
+  /// proof の二重使用を検知（既に spend 済み）
+  doubleSpend,
+
+  /// Lightning invoice の生成・支払に失敗
+  lightningFailed,
+
+  /// ゴールが見つからない
+  goalNotFound,
+
+  /// 暗号化に失敗
+  encryptionFailed,
+
+  /// 復号化に失敗
+  decryptionFailed,
+}
+
+/// 貯金機能固有の Failure
+class SavingsFailure extends Failure {
+  const SavingsFailure(this.error, {String? customMessage})
+    : super(customMessage ?? '');
+
+  final SavingsError error;
+
+  @override
+  String get message {
+    final base = _errorMessage(error);
+    final custom = super.message;
+    return custom.isEmpty ? base : '$base: $custom';
+  }
+
+  static String _errorMessage(SavingsError error) {
+    switch (error) {
+      case SavingsError.mintUnreachable:
+        return 'mintに接続できませんでした';
+      case SavingsError.mintRejected:
+        return 'mintが要求を拒否しました';
+      case SavingsError.insufficientProofs:
+        return '残高が不足しています';
+      case SavingsError.redeemFailed:
+        return 'NutZapの回収に失敗しました';
+      case SavingsError.walletSyncFailed:
+        return 'ウォレットの同期に失敗しました';
+      case SavingsError.doubleSpend:
+        return 'この残高は既に使用済みです（二重使用）';
+      case SavingsError.lightningFailed:
+        return 'Lightningの処理に失敗しました';
+      case SavingsError.goalNotFound:
+        return '貯金ゴールが見つかりませんでした';
+      case SavingsError.encryptionFailed:
+        return '暗号化に失敗しました';
+      case SavingsError.decryptionFailed:
+        return '復号化に失敗しました';
+    }
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SavingsFailure &&
+          error == other.error &&
+          message == other.message;
+
+  @override
+  int get hashCode => Object.hash(runtimeType, error, message);
+}

--- a/lib/features/savings/domain/repositories/cashu_wallet_repository.dart
+++ b/lib/features/savings/domain/repositories/cashu_wallet_repository.dart
@@ -1,0 +1,101 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/common/failure.dart';
+import '../entities/cashu_proof.dart';
+import '../entities/goal_balance.dart';
+
+/// Cashu ウォレットのリポジトリインターフェース
+///
+/// Cashu の proof（ecash）操作を抽象化する。実装は Infrastructure 層で
+/// Rust（cdk）FFI をラップする（`rust/src/cashu.rs`）。
+///
+/// 責務:
+/// - Lightning invoice 経由の発行（mint）/ 払い出し（melt）/ 交換（swap）
+/// - proof のローカル保管と NIP-60（kind 7375 暗号化）への同期
+/// - ゴール単位の残高算出
+///
+/// セキュリティ:
+/// - proof は bearer 資産。実装は secret / C をログに出さないこと
+/// - 乱数は cdk 内蔵 CSPRNG を使用（自前の Math.random / rand 禁止）
+abstract class CashuWalletRepository {
+  // ============================================================
+  // 発行 / 払い出し（Lightning 連携）
+  // ============================================================
+
+  /// 指定額の発行用 Lightning invoice を作成する（mint quote）。
+  ///
+  /// 戻り値: [MintQuote]（支払うべき bolt11 と quote ID）
+  Future<Either<Failure, MintQuote>> createDepositInvoice({
+    required String mintUrl,
+    required int amountSats,
+  });
+
+  /// invoice の支払を検知して proof を発行・受領する（mint）。
+  ///
+  /// 受領した proof は [goalId] のウォレットに保存する。
+  /// 戻り値: 発行された proof 群
+  Future<Either<Failure, List<CashuProof>>> redeemDepositInvoice({
+    required String goalId,
+    required String mintUrl,
+    required String quoteId,
+  });
+
+  /// proof を Lightning へ払い出す（melt）。掃き出し / 出金に使用。
+  ///
+  /// [destinationInvoice] は払い出し先の bolt11。
+  /// 戻り値: 実際に払い出した額（手数料控除後の sat）
+  Future<Either<Failure, int>> withdrawToLightning({
+    required String goalId,
+    required String mintUrl,
+    required String destinationInvoice,
+  });
+
+  // ============================================================
+  // proof 操作 / 残高
+  // ============================================================
+
+  /// proof を新しい proof に交換する（swap）。
+  /// NutZap 回収後の自ウォレットへの取り込み等で使用。
+  Future<Either<Failure, List<CashuProof>>> swap({
+    required String mintUrl,
+    required List<CashuProof> proofs,
+  });
+
+  /// ゴールの現在残高（未使用 proof 合計）を取得する。
+  Future<Either<Failure, GoalBalance>> getBalance({
+    required String goalId,
+    required int targetSats,
+  });
+
+  // ============================================================
+  // 永続化 / 同期（NIP-60）
+  // ============================================================
+
+  /// ゴールの proof をローカル + NIP-60（kind 7375 暗号化）に保存する。
+  Future<Either<Failure, void>> persistProofs({
+    required String goalId,
+    required List<CashuProof> proofs,
+  });
+
+  /// ゴールの proof をローカル / NIP-60 から読み込む。
+  Future<Either<Failure, List<CashuProof>>> loadProofs({
+    required String goalId,
+  });
+}
+
+/// mint quote（発行用 invoice）
+class MintQuote {
+  const MintQuote({
+    required this.quoteId,
+    required this.bolt11,
+    required this.amountSats,
+  });
+
+  /// mint が払い出す quote の識別子
+  final String quoteId;
+
+  /// 支払うべき Lightning invoice（bolt11）
+  final String bolt11;
+
+  /// 発行予定額（sat）
+  final int amountSats;
+}

--- a/lib/features/savings/domain/repositories/nutzap_repository.dart
+++ b/lib/features/savings/domain/repositories/nutzap_repository.dart
@@ -1,0 +1,72 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/common/failure.dart';
+import '../entities/cashu_proof.dart';
+import '../entities/nutzap_contribution.dart';
+
+/// NutZap（NIP-61）のリポジトリインターフェース
+///
+/// 協同貯金で他者からの NutZap を受け取り、自ウォレットに回収する経路を
+/// 抽象化する。実装は Infrastructure 層で Rust（`rust/src/nutzap.rs`）と
+/// nostr-sdk をラップする。
+///
+/// フロー:
+/// 1. [publishNutzapInfo] でゴールの mint と P2PK 公開鍵を kind 10019 で宣言
+/// 2. 送り手は [sendNutzap] で受取人の P2PK 鍵にロックした kind 9321 を発行
+/// 3. 受取側は [fetchIncomingNutzaps] で着信を取得し [redeemNutzap] で回収（swap）
+abstract class NutzapRepository {
+  /// ゴールの受取情報（mint + P2PK 公開鍵）を kind 10019 で公開する。
+  /// 協同ゴール作成時に呼ぶ。
+  Future<Either<Failure, void>> publishNutzapInfo({
+    required String mintUrl,
+    required String p2pkPubkey,
+  });
+
+  /// 指定ゴール（受取人の P2PK 鍵）に向けて NutZap（kind 9321）を送る。
+  ///
+  /// [proofs] は受取人の P2PK 鍵にロック済みの proof。
+  Future<Either<Failure, void>> sendNutzap({
+    required String recipientPubkey,
+    required String mintUrl,
+    required List<CashuProof> proofs,
+    String? comment,
+  });
+
+  /// ゴール宛の未回収 NutZap（kind 9321）を取得する。
+  Future<Either<Failure, List<IncomingNutzap>>> fetchIncomingNutzaps({
+    required String goalId,
+    required String p2pkPubkey,
+  });
+
+  /// 着信 NutZap を自ウォレットに回収（swap）し、貢献記録を返す。
+  /// 回収済みの eventId は二重回収しないこと。
+  Future<Either<Failure, NutzapContribution>> redeemNutzap({
+    required String goalId,
+    required IncomingNutzap nutzap,
+  });
+}
+
+/// 着信した NutZap（未回収）
+class IncomingNutzap {
+  const IncomingNutzap({
+    required this.eventId,
+    required this.senderPubkey,
+    required this.mintUrl,
+    required this.proofs,
+    this.comment,
+  });
+
+  /// kind 9321 イベントID（回収済み判定のキー）
+  final String eventId;
+
+  /// 送り主公開鍵（hex）
+  final String senderPubkey;
+
+  /// proof を発行した mint
+  final String mintUrl;
+
+  /// P2PK ロックされた proof 群
+  final List<CashuProof> proofs;
+
+  /// 任意メッセージ
+  final String? comment;
+}

--- a/lib/features/savings/domain/repositories/savings_goal_repository.dart
+++ b/lib/features/savings/domain/repositories/savings_goal_repository.dart
@@ -1,0 +1,30 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/common/failure.dart';
+import '../entities/savings_goal.dart';
+
+/// 貯金ゴールのリポジトリインターフェース
+///
+/// ゴール定義（メタデータ）の CRUD を抽象化する。実体は既存の
+/// CustomList（Kind 30001 + LWW 同期）に委譲し、貯金固有のメタ
+/// （目標額・mint・P2PK・期日）を上乗せして永続化する。
+///
+/// 実装は `custom_list_repository_impl.dart` のパターンを踏襲する。
+abstract class SavingsGoalRepository {
+  /// ローカル + Nostr から全貯金ゴールを読み込む。
+  Future<Either<Failure, List<SavingsGoal>>> loadGoals();
+
+  /// 単一ゴールを取得する。
+  Future<Either<Failure, SavingsGoal>> getGoal(String goalId);
+
+  /// ゴールを作成し、ローカル + Nostr（Kind 30001）へ保存する。
+  Future<Either<Failure, SavingsGoal>> createGoal(SavingsGoal goal);
+
+  /// ゴールのメタデータを更新する（名前・目標額・期日など）。
+  Future<Either<Failure, void>> updateGoal(SavingsGoal goal);
+
+  /// ゴールを削除する（Kind 5 tombstone）。
+  ///
+  /// ⚠️ 実装は削除前に残高が 0 でないことを呼び出し側が確認している前提。
+  /// 残高がある状態の削除は資産消失につながるため UseCase 側でガードする。
+  Future<Either<Failure, void>> deleteGoal(String goalId);
+}

--- a/lib/features/savings/domain/value_objects/target_amount.dart
+++ b/lib/features/savings/domain/value_objects/target_amount.dart
@@ -1,0 +1,45 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/common/failure.dart';
+
+/// 貯金ゴールの目標額（Value Object, 単位: sat）
+///
+/// ビジネスルール:
+/// - 1 sat 以上（0 や負数は不可）
+/// - 上限 100,000,000 sat（= 1 BTC）。貯金用途として現実的な上限を設ける
+class TargetAmount {
+  const TargetAmount._(this.sats);
+
+  /// 検証なしで作成（既存データ読み込み時）
+  factory TargetAmount.unsafe(int sats) => TargetAmount._(sats);
+
+  final int sats;
+
+  /// 上限（1 BTC 相当）
+  static const int maxSats = 100000000;
+
+  /// バリデーション付きファクトリー
+  ///
+  /// ユーザー入力から作成する際に使用。
+  /// 不正な場合は Left(ValidationFailure) を返す。
+  static Either<Failure, TargetAmount> create(int input) {
+    if (input < 1) {
+      return const Left(ValidationFailure('目標額は1 sat以上にしてください'));
+    }
+    if (input > maxSats) {
+      return const Left(
+        ValidationFailure('目標額は1 BTC（100,000,000 sat）以内にしてください'),
+      );
+    }
+    return Right(TargetAmount._(input));
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is TargetAmount && sats == other.sats;
+
+  @override
+  int get hashCode => sats.hashCode;
+
+  @override
+  String toString() => '$sats sat';
+}

--- a/test/features/savings/domain/entities/goal_balance_test.dart
+++ b/test/features/savings/domain/entities/goal_balance_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meiso/features/savings/domain/entities/goal_balance.dart';
+
+void main() {
+  group('GoalBalance', () {
+    GoalBalance balance(int current, int target) => GoalBalance(
+      goalId: 'g1',
+      currentSats: current,
+      targetSats: target,
+    );
+
+    group('progress', () {
+      test('半分貯まっていれば0.5', () {
+        expect(balance(500, 1000).progress, 0.5);
+      });
+
+      test('0なら0.0', () {
+        expect(balance(0, 1000).progress, 0.0);
+      });
+
+      test('超過しても1.0でクランプされる', () {
+        expect(balance(1500, 1000).progress, 1.0);
+      });
+
+      test('targetが0なら0.0（ゼロ除算回避）', () {
+        expect(balance(100, 0).progress, 0.0);
+      });
+    });
+
+    group('isReached', () {
+      test('目標到達でtrue', () {
+        expect(balance(1000, 1000).isReached, true);
+        expect(balance(1200, 1000).isReached, true);
+      });
+
+      test('未達でfalse', () {
+        expect(balance(999, 1000).isReached, false);
+      });
+
+      test('targetが0ならfalse', () {
+        expect(balance(0, 0).isReached, false);
+      });
+    });
+
+    group('remainingSats', () {
+      test('残額を返す', () {
+        expect(balance(300, 1000).remainingSats, 700);
+      });
+
+      test('超過しても0未満にはならない', () {
+        expect(balance(1200, 1000).remainingSats, 0);
+      });
+    });
+  });
+}

--- a/test/features/savings/domain/entities/savings_goal_test.dart
+++ b/test/features/savings/domain/entities/savings_goal_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meiso/features/savings/domain/entities/savings_goal.dart';
+
+void main() {
+  group('SavingsGoal', () {
+    SavingsGoal goal({DateTime? deadline}) => SavingsGoal(
+      goalId: 'trip-fund',
+      name: 'TRIP FUND',
+      targetSats: 100000,
+      mintUrl: 'https://mint.example',
+      deadline: deadline,
+      createdAt: DateTime(2026),
+    );
+
+    test('dTagはプレフィックス付きで生成される', () {
+      expect(goal().dTag, 'meiso-savings-trip-fund');
+    });
+
+    test('デフォルトは個人・sat建て', () {
+      final g = goal();
+      expect(g.isCollaborative, false);
+      expect(g.currency, 'sat');
+      expect(g.p2pkPubkey, isNull);
+    });
+
+    group('isPastDeadline', () {
+      test('期日未設定なら常にfalse', () {
+        expect(goal().isPastDeadline(DateTime(2030)), false);
+      });
+
+      test('期日前はfalse', () {
+        final g = goal(deadline: DateTime(2026, 12, 31));
+        expect(g.isPastDeadline(DateTime(2026, 6)), false);
+      });
+
+      test('期日後はtrue', () {
+        final g = goal(deadline: DateTime(2026, 1, 31));
+        expect(g.isPastDeadline(DateTime(2026, 2)), true);
+      });
+    });
+
+    test('JSONラウンドトリップで等価', () {
+      final g = goal(deadline: DateTime(2026, 12, 31));
+      final restored = SavingsGoal.fromJson(g.toJson());
+      expect(restored, g);
+    });
+  });
+}

--- a/test/features/savings/domain/value_objects/target_amount_test.dart
+++ b/test/features/savings/domain/value_objects/target_amount_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meiso/core/common/failure.dart';
+import 'package:meiso/features/savings/domain/value_objects/target_amount.dart';
+
+void main() {
+  group('TargetAmount', () {
+    group('create', () {
+      test('1 sat以上ならTargetAmountを作成できる', () {
+        final result = TargetAmount.create(1000);
+
+        expect(result.isRight(), true);
+        result.fold(
+          (failure) => fail('Should succeed'),
+          (amount) => expect(amount.sats, 1000),
+        );
+      });
+
+      test('0 satはValidationFailureを返す', () {
+        final result = TargetAmount.create(0);
+
+        expect(result.isLeft(), true);
+        result.fold(
+          (failure) {
+            expect(failure, isA<ValidationFailure>());
+            expect(failure.message, '目標額は1 sat以上にしてください');
+          },
+          (_) => fail('Should fail'),
+        );
+      });
+
+      test('負数はValidationFailureを返す', () {
+        final result = TargetAmount.create(-1);
+
+        expect(result.isLeft(), true);
+      });
+
+      test('上限（1 BTC）ちょうどはOK', () {
+        final result = TargetAmount.create(TargetAmount.maxSats);
+
+        expect(result.isRight(), true);
+      });
+
+      test('上限を超えるとValidationFailureを返す', () {
+        final result = TargetAmount.create(TargetAmount.maxSats + 1);
+
+        expect(result.isLeft(), true);
+        result.fold(
+          (failure) {
+            expect(failure, isA<ValidationFailure>());
+            expect(failure.message, '目標額は1 BTC（100,000,000 sat）以内にしてください');
+          },
+          (_) => fail('Should fail'),
+        );
+      });
+    });
+
+    group('equality', () {
+      test('同じ値は等しい', () {
+        final a = TargetAmount.unsafe(500);
+        final b = TargetAmount.unsafe(500);
+
+        expect(a, b);
+        expect(a.hashCode, b.hashCode);
+      });
+
+      test('異なる値は等しくない', () {
+        final a = TargetAmount.unsafe(500);
+        final b = TargetAmount.unsafe(600);
+
+        expect(a, isNot(b));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Overview

A **savings custom list** where you set a goal amount, zap, and stack sats (personal savings + collaborative savings). A new domain layered on top of the existing custom-list foundation, adding Cashu ecash / NutZap (NIP-60/61).

Release is some way off, so this PR is run as an **umbrella that stacks each Phase (leaf) in sequence**. Stays draft until done.

Design plan: `~/.claude/plans/zap-nips-nutzap-harmonic-pearl.md`

## Confirmed direction (from discussion)
- Usage = both personal savings and collaborative savings (personal as the base, expand to collaborative)
- Locking = UX lock only (hide withdrawal until goal/due date; no P2PK locktime)
- mint = single for MVP, data model is mint-agnostic, melt (LN sweep-out) as fast-follow
- Default mint = **Minibits** (`https://mint.minibits.cash/Bitcoin`)

## Phase progress
- [x] **Phase 0: Domain contract** (this commit)
  - `lib/features/savings/domain/`: SavingsGoal / CashuProof / GoalBalance / NutzapContribution, TargetAmount VO, SavingsError, 3 Repository IFs
  - CashuProof is a bearer asset, so `toString` masks secret/C
  - dart analyze green / 22 unit tests green / formatted / security-max-audit pass (zero Critical/High)
- [ ] Phase 1: Personal savings MVP (Rust cdk or cdk-dart + per-layer implementation, end-to-end save → withdraw)
- [ ] Phase 2: Collaborative savings + LN sweep (NIP-60/61, kind 10019/9321)
- [ ] Phase 3: Hardening (multiple mints / bearer backup / multi-device double-spend guard)

## Carried-forward security contracts
- `CashuProof.toJson()` exposes secret/C in plaintext, so Phase 1 implementation must keep it **only inside NIP-44-encrypted payloads** — no plaintext logging/persistence
- mint URL TLS required, hex/format validation at boundaries, `cargo audit` when cdk is added

## Leaf Node ops
Each Phase is developed in its own worktree/branch and merged into this `claude/modest-swartz-64b4a4` to stack (not yet merged to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
