### PR TITLE
ci(build-apk): surface Telegram notify failures + require chat id

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -104,8 +104,8 @@ jobs:
           SHA: ${{ github.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ -z "$TELEGRAM_BOT_TOKEN" ]; then
-            echo "No Telegram token configured, skipping notification"
+          if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
+            echo "Telegram token/chat id is not fully configured, skipping notification"
             exit 0
           fi
           SHORT_SHA=${SHA::7}
@@ -120,7 +120,7 @@ jobs:
           Commit: \`${SHORT_SHA}\`
           [See logs](${RUN_URL})"
           fi
-          curl -s -X POST \
+          curl -fsS -X POST \
             "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -d chat_id="${TELEGRAM_CHAT_ID}" \
             -d parse_mode="Markdown" \


### PR DESCRIPTION
## Summary

- The `notify` job was silently swallowing Telegram delivery failures (`curl -s` masks HTTP errors), so even though the bot token had been invalidated, the job stayed green and nobody noticed
- Digging through past logs shows **every run since 2026-04-06 has had the Telegram API return `401 Unauthorized`** (4/6 was the last successful delivery), yet the Actions UI displayed the notify step as success
- Defensively, only 2 lines changed:
  - Include `TELEGRAM_CHAT_ID` in the required-secret check alongside `TELEGRAM_BOT_TOKEN`
  - Change `curl -s` → `curl -fsS` so the step exits non-zero on >=400 and dumps the response body

## Why not just merge `openclaw/fix-telegram-notify-secrets`?

A March branch with the same 2 lines already exists, but it's based off too old a commit (`071da1e`, 2026-03-18). Merging it as-is would revert all of the following improvements that landed on main since:

- GitHub Actions v4 → v5
- production flavor → beta flavor switch
- added `--target-platform android-arm64`
- vendored cargokit (removed submodule init)
- removed keystore signing block
- added `Run tests` step

So the old branch should be closed. This PR is rebased off main and only applies the 2-line change.

## Important: this PR alone does NOT restore notifications

The value of the `TELEGRAM_BOT_TOKEN` GitHub secret hasn't changed since 2026-03-18, but the token has been revoked on Telegram's side. To restore delivery, separately:

1. @BotFather → `/mybots` → `aidenxxx_bot` → API Token → Revoke → get new token (if the bot itself is gone, recreate it and update `TELEGRAM_CHAT_ID` too)
2. `gh secret set TELEGRAM_BOT_TOKEN -R higedamc/meiso`
3. Verify via `workflow_dispatch` or a dummy push to `openclaw/*`

The benefit of this PR is: "the next time the token dies, we'll actually notice."

## Test plan

- [ ] A push to `openclaw/harden-telegram-notify` triggers a build-apk run where the `notify` step shows as **failure** (with the currently broken token still in place) — confirming the `curl -fsS` effect
- [ ] After reissuing the bot token, a `workflow_dispatch` re-run delivers the Markdown message to Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)
