### PR TITLE
feat: add Collaborative Lists section to in-app Cryptography Details

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2626,6 +2626,51 @@ abstract class AppLocalizations {
   /// **'8. Threat Model and Limitations'**
   String get cryptoTocItem8;
 
+  /// ToC item 9 - Collaborative Lists
+  ///
+  /// In en, this message translates to:
+  /// **'9. Collaborative Lists - Hybrid Encryption'**
+  String get cryptoTocItem9;
+
+  /// Collaborative lists section title
+  String get cryptoCollabListsTitle;
+
+  /// Collaborative lists intro paragraph
+  String get cryptoCollabListsIntro;
+
+  /// Collaborative lists hybrid scheme subheading
+  String get cryptoCollabHybridTitle;
+
+  /// Collaborative lists hybrid scheme description
+  String get cryptoCollabHybridDesc;
+
+  /// Collaborative lists encryption flow code block
+  String get cryptoCollabEncryptionFlow;
+
+  /// Collaborative lists membership changes subheading
+  String get cryptoCollabMembershipTitle;
+
+  /// Add member description
+  String get cryptoCollabAddMember;
+
+  /// Add member detail
+  String get cryptoCollabAddMemberDesc;
+
+  /// Remove member description (forward secrecy)
+  String get cryptoCollabRemoveMember;
+
+  /// Remove member detail
+  String get cryptoCollabRemoveMemberDesc;
+
+  /// Collaborative lists primitives subheading
+  String get cryptoCollabPrimitivesTitle;
+
+  /// Collaborative lists primitives code block
+  String get cryptoCollabPrimitivesTable;
+
+  /// Collaborative lists reference link text
+  String get cryptoCollabReference;
+
   /// Footer security title
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1439,6 +1439,79 @@ class AppLocalizationsEn extends AppLocalizations {
   String get cryptoTocItem8 => '8. Threat Model and Limitations';
 
   @override
+  String get cryptoTocItem9 => '9. Collaborative Lists - Hybrid Encryption';
+
+  @override
+  String get cryptoCollabListsTitle =>
+      '9. Collaborative Lists — Hybrid Encryption';
+
+  @override
+  String get cryptoCollabListsIntro =>
+      'Shared lists use a two-layer hybrid encryption scheme so that task data '
+      'is encrypted once, yet any authorised member can independently decrypt '
+      'it using only their own Nostr keypair — no trusted key server required.';
+
+  @override
+  String get cryptoCollabHybridTitle => 'How the Hybrid Scheme Works';
+
+  @override
+  String get cryptoCollabHybridDesc =>
+      'A random 256-bit AES key encrypts the list payload (AES-256-GCM). That '
+      'AES key is then wrapped individually for every member using NIP-44 v2 '
+      '(ECDH over secp256k1 → HKDF-SHA256 → ChaCha20-Poly1305). Each member '
+      'stores one small encrypted blob; the bulk ciphertext is shared.';
+
+  @override
+  String get cryptoCollabEncryptionFlow =>
+      'Encrypt\n'
+      '  tasks (JSON) ──AES-256-GCM (random key + 12-byte nonce)──► ciphertext\n'
+      '\n'
+      'Wrap key per member\n'
+      '  owner_sk × member_pk ──ECDH──► shared_secret\n'
+      '  shared_secret ──HKDF-SHA256──► wrap_key\n'
+      '  wrap_key ──NIP-44 v2──► encrypted_aes_key\n'
+      '\n'
+      'Publish Nostr event\n'
+      '  { encrypted_data, members[], encrypted_keys[] }';
+
+  @override
+  String get cryptoCollabMembershipTitle => 'Membership Changes';
+
+  @override
+  String get cryptoCollabAddMember => 'Adding a member';
+
+  @override
+  String get cryptoCollabAddMemberDesc =>
+      'Wrap the existing AES key for the new member with NIP-44 v2. '
+      'No re-encryption of the list payload is required.';
+
+  @override
+  String get cryptoCollabRemoveMember => 'Removing a member (forward secrecy)';
+
+  @override
+  String get cryptoCollabRemoveMemberDesc =>
+      'Generate a fresh random AES key, re-encrypt the entire list, and '
+      're-wrap the new key for all remaining members. The removed member\'s '
+      'old encrypted_aes_key becomes permanently useless.';
+
+  @override
+  String get cryptoCollabPrimitivesTitle => 'Cryptographic Primitives';
+
+  @override
+  String get cryptoCollabPrimitivesTable =>
+      'Layer               Algorithm\n'
+      '─────────────────────────────────────────────\n'
+      'List encryption     AES-256-GCM\n'
+      'Key agreement       ECDH / secp256k1 (NIP-44 v2)\n'
+      'Key derivation      HKDF-SHA256 (inside NIP-44)\n'
+      'RNG                 OsRng (OS-provided CSPRNG)\n'
+      'Event authenticity  Schnorr / secp256k1 (Nostr)';
+
+  @override
+  String get cryptoCollabReference =>
+      '📚 Design doc: docs/COLLABORATIVE_LISTS_ENCRYPTION.md';
+
+  @override
   String get cryptoFooterSecurityTitle => '🔒 Security Questions and Reports';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1458,6 +1458,81 @@ class AppLocalizationsEs extends AppLocalizations {
   String get cryptoTocItem8 => '8. Modelo de Amenazas y Limitaciones';
 
   @override
+  String get cryptoTocItem9 => '9. Listas Colaborativas - Cifrado Híbrido';
+
+  @override
+  String get cryptoCollabListsTitle =>
+      '9. Listas Colaborativas — Cifrado Híbrido';
+
+  @override
+  String get cryptoCollabListsIntro =>
+      'Las listas compartidas utilizan un esquema de cifrado híbrido de dos capas: '
+      'los datos de tareas se cifran una sola vez, pero cualquier miembro autorizado '
+      'puede descifrarlos de forma independiente usando únicamente su propio par de '
+      'claves Nostr, sin necesidad de un servidor de claves de confianza.';
+
+  @override
+  String get cryptoCollabHybridTitle => 'Cómo Funciona el Esquema Híbrido';
+
+  @override
+  String get cryptoCollabHybridDesc =>
+      'Una clave AES aleatoria de 256 bits cifra el payload de la lista (AES-256-GCM). '
+      'Esa clave AES se envuelve individualmente para cada miembro usando NIP-44 v2 '
+      '(ECDH sobre secp256k1 → HKDF-SHA256 → ChaCha20-Poly1305). Cada miembro '
+      'almacena un pequeño blob cifrado; el texto cifrado principal es compartido.';
+
+  @override
+  String get cryptoCollabEncryptionFlow =>
+      'Cifrar\n'
+      '  tareas (JSON) ──AES-256-GCM (clave aleatoria + nonce 12 bytes)──► cifrado\n'
+      '\n'
+      'Envolver clave por miembro\n'
+      '  owner_sk × member_pk ──ECDH──► secreto_compartido\n'
+      '  secreto_compartido ──HKDF-SHA256──► clave_envoltura\n'
+      '  clave_envoltura ──NIP-44 v2──► encrypted_aes_key\n'
+      '\n'
+      'Publicar evento Nostr\n'
+      '  { encrypted_data, members[], encrypted_keys[] }';
+
+  @override
+  String get cryptoCollabMembershipTitle => 'Cambios de Membresía';
+
+  @override
+  String get cryptoCollabAddMember => 'Agregar un miembro';
+
+  @override
+  String get cryptoCollabAddMemberDesc =>
+      'Envuelve la clave AES existente para el nuevo miembro con NIP-44 v2. '
+      'No se requiere re-cifrado del payload de la lista.';
+
+  @override
+  String get cryptoCollabRemoveMember =>
+      'Eliminar un miembro (secreto hacia adelante)';
+
+  @override
+  String get cryptoCollabRemoveMemberDesc =>
+      'Genera una nueva clave AES aleatoria, re-cifra toda la lista y '
+      're-envuelve la nueva clave para todos los miembros restantes. '
+      'El encrypted_aes_key antiguo del miembro eliminado queda permanentemente inútil.';
+
+  @override
+  String get cryptoCollabPrimitivesTitle => 'Primitivas Criptográficas';
+
+  @override
+  String get cryptoCollabPrimitivesTable =>
+      'Capa                  Algoritmo\n'
+      '─────────────────────────────────────────────\n'
+      'Cifrado de lista      AES-256-GCM\n'
+      'Acuerdo de clave      ECDH / secp256k1 (NIP-44 v2)\n'
+      'Derivación de clave   HKDF-SHA256 (dentro de NIP-44)\n'
+      'RNG                   OsRng (CSPRNG del SO)\n'
+      'Autenticidad evento   Schnorr / secp256k1 (Nostr)';
+
+  @override
+  String get cryptoCollabReference =>
+      '📚 Documento de diseño: docs/COLLABORATIVE_LISTS_ENCRYPTION.md';
+
+  @override
   String get cryptoFooterSecurityTitle =>
       '🔒 Preguntas y Reportes de Seguridad';
 

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1393,6 +1393,78 @@ class AppLocalizationsJa extends AppLocalizations {
   String get cryptoTocItem8 => '8. 脅威モデルと制限事項';
 
   @override
+  String get cryptoTocItem9 => '9. 共有リスト - ハイブリッド暗号化';
+
+  @override
+  String get cryptoCollabListsTitle => '9. 共有リスト — ハイブリッド暗号化';
+
+  @override
+  String get cryptoCollabListsIntro =>
+      '共有リストは2層のハイブリッド暗号化方式を採用しています。タスクデータは一度だけ暗号化されますが、'
+      '許可されたメンバーは全員、自身のNostrキーペアのみを使って独立して復号できます。'
+      '信頼できる鍵サーバーは不要です。';
+
+  @override
+  String get cryptoCollabHybridTitle => 'ハイブリッド方式の仕組み';
+
+  @override
+  String get cryptoCollabHybridDesc =>
+      'ランダムな256ビットのAES鍵がリストのペイロードを暗号化します（AES-256-GCM）。'
+      'その鍵はメンバーごとにNIP-44 v2（ECDH over secp256k1 → HKDF-SHA256 → ChaCha20-Poly1305）'
+      'を使って個別にラップされます。各メンバーは小さな暗号化ブロブを1つ保持し、'
+      'バルク暗号文は共有されます。';
+
+  @override
+  String get cryptoCollabEncryptionFlow =>
+      '暗号化\n'
+      '  tasks (JSON) ──AES-256-GCM (ランダム鍵 + 12バイトnonce)──► 暗号文\n'
+      '\n'
+      'メンバーごとに鍵をラップ\n'
+      '  owner_sk × member_pk ──ECDH──► 共有シークレット\n'
+      '  共有シークレット ──HKDF-SHA256──► ラップ鍵\n'
+      '  ラップ鍵 ──NIP-44 v2──► encrypted_aes_key\n'
+      '\n'
+      'Nostrイベントを公開\n'
+      '  { encrypted_data, members[], encrypted_keys[] }';
+
+  @override
+  String get cryptoCollabMembershipTitle => 'メンバーシップの変更';
+
+  @override
+  String get cryptoCollabAddMember => 'メンバーの追加';
+
+  @override
+  String get cryptoCollabAddMemberDesc =>
+      '既存のAES鍵をNIP-44 v2で新メンバー用にラップするだけです。'
+      'リストのペイロードの再暗号化は不要です。';
+
+  @override
+  String get cryptoCollabRemoveMember => 'メンバーの削除（前方秘匿性）';
+
+  @override
+  String get cryptoCollabRemoveMemberDesc =>
+      '新しいランダムなAES鍵を生成し、リスト全体を再暗号化して、'
+      '残りの全メンバー用に新しい鍵を再ラップします。'
+      '削除されたメンバーの古いencrypted_aes_keyは永続的に無効になります。';
+
+  @override
+  String get cryptoCollabPrimitivesTitle => '使用する暗号プリミティブ';
+
+  @override
+  String get cryptoCollabPrimitivesTable =>
+      'レイヤー               アルゴリズム\n'
+      '─────────────────────────────────────────────\n'
+      'リスト暗号化           AES-256-GCM\n'
+      '鍵共有                 ECDH / secp256k1 (NIP-44 v2)\n'
+      '鍵導出                 HKDF-SHA256 (NIP-44内部)\n'
+      'RNG                    OsRng (OS提供のCSPRNG)\n'
+      'イベント真正性          Schnorr / secp256k1 (Nostr)';
+
+  @override
+  String get cryptoCollabReference =>
+      '📚 設計文書: docs/COLLABORATIVE_LISTS_ENCRYPTION.md';
+
+  @override
   String get cryptoFooterSecurityTitle => '🔒 セキュリティに関する質問や報告';
 
   @override

--- a/lib/presentation/settings/cryptography_detail_screen.dart
+++ b/lib/presentation/settings/cryptography_detail_screen.dart
@@ -498,6 +498,74 @@ class CryptographyDetailScreen extends StatelessWidget {
 
                   const SizedBox(height: 40),
 
+                  // セクション9: 共有リスト暗号化
+                  _buildSection(
+                    context,
+                    id: 'collab-lists',
+                    icon: Icons.group_outlined,
+                    title: AppLocalizations.of(context).cryptoCollabListsTitle,
+                    content: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _buildParagraph(
+                          context,
+                          AppLocalizations.of(context).cryptoCollabListsIntro,
+                        ),
+                        const SizedBox(height: 16),
+                        _buildSubheading(
+                            context,
+                            AppLocalizations.of(context)
+                                .cryptoCollabHybridTitle),
+                        _buildParagraph(
+                          context,
+                          AppLocalizations.of(context).cryptoCollabHybridDesc,
+                        ),
+                        const SizedBox(height: 16),
+                        _buildCodeBlock(
+                          context,
+                          AppLocalizations.of(context)
+                              .cryptoCollabEncryptionFlow,
+                        ),
+                        const SizedBox(height: 16),
+                        _buildSubheading(
+                            context,
+                            AppLocalizations.of(context)
+                                .cryptoCollabMembershipTitle),
+                        _buildBulletPoint(
+                          context,
+                          AppLocalizations.of(context).cryptoCollabAddMember,
+                          AppLocalizations.of(context)
+                              .cryptoCollabAddMemberDesc,
+                        ),
+                        _buildBulletPoint(
+                          context,
+                          AppLocalizations.of(context)
+                              .cryptoCollabRemoveMember,
+                          AppLocalizations.of(context)
+                              .cryptoCollabRemoveMemberDesc,
+                        ),
+                        const SizedBox(height: 16),
+                        _buildSubheading(
+                            context,
+                            AppLocalizations.of(context)
+                                .cryptoCollabPrimitivesTitle),
+                        _buildCodeBlock(
+                          context,
+                          AppLocalizations.of(context)
+                              .cryptoCollabPrimitivesTable,
+                        ),
+                        const SizedBox(height: 12),
+                        _buildLinkText(
+                          context,
+                          AppLocalizations.of(context).cryptoCollabReference,
+                          'https://github.com/higedamc/meiso/blob/main/docs/COLLABORATIVE_LISTS_ENCRYPTION.md',
+                        ),
+                      ],
+                    ),
+                  ),
+
+                  const SizedBox(height: 40),
+
                   // フッター
                   _buildFooter(context),
 
@@ -564,6 +632,7 @@ class CryptographyDetailScreen extends StatelessWidget {
           _buildTocItem(context, AppLocalizations.of(context).cryptoTocItem6),
           _buildTocItem(context, AppLocalizations.of(context).cryptoTocItem7),
           _buildTocItem(context, AppLocalizations.of(context).cryptoTocItem8),
+          _buildTocItem(context, AppLocalizations.of(context).cryptoTocItem9),
         ],
       ),
     );


### PR DESCRIPTION
## Summary

- Adds **Section 9 — Collaborative Lists (Hybrid Encryption)** to the in-app Cryptography Details screen (`cryptography_detail_screen.dart`)
- Updates table of contents to include the new section
- Adds all required localization strings in **EN / JA / ES** (`app_localizations*.dart`)

## What's covered in the new section

- Overview of the two-layer hybrid scheme (AES-256-GCM payload + NIP-44 v2 key wrapping)
- Encryption flow diagram (code block)
- Membership changes: adding members (no re-encryption needed) vs. removing members (full key rotation / forward secrecy)
- Cryptographic primitives table: AES-256-GCM, ECDH/secp256k1, HKDF-SHA256, OsRng, Schnorr
- Link to the full design doc added in #149 (`docs/COLLABORATIVE_LISTS_ENCRYPTION.md`)

## Test plan

- [ ] Build and open Settings → Cryptography Details
- [ ] Scroll to Section 9 and verify text renders correctly
- [ ] Switch locale to JA and ES, verify translations appear
- [ ] Tap the design doc link — should open GitHub URL in external browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)