### PR TITLE
feat: add Collaborative Lists section to in-app Cryptography Details

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2257,7 +2257,7 @@
     "description": "Collaborative lists hybrid scheme description"
   },
 
-  "cryptoCollabEncryptionFlow": "Encrypt\n  tasks (JSON) ──AES-256-GCM (random key + 12-byte nonce)──► ciphertext\n\nWrap key per member\n  owner_sk × member_pk ──ECDH──► shared_secret\n  shared_secret ──HKDF-SHA256──► wrap_key\n  wrap_key ──NIP-44 v2──► encrypted_aes_key\n\nPublish Nostr event\n  '{' encrypted_data, members[], encrypted_keys[] '}'",
+  "cryptoCollabEncryptionFlow": "Encrypt\n  tasks (JSON) ──AES-256-GCM (random key + 12-byte nonce)──► ciphertext\n\nWrap key per member\n  owner_sk × member_pk ──ECDH──► shared_secret\n  shared_secret ──HKDF-SHA256──► wrap_key\n  wrap_key ──NIP-44 v2──► encrypted_aes_key\n\nPublish Nostr event\n  fields: encrypted_data, members[], encrypted_keys[]",
   "@cryptoCollabEncryptionFlow": {
     "description": "Collaborative lists encryption flow code block"
   },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2232,6 +2232,76 @@
     "description": "Table of contents item 8"
   },
   
+  "cryptoTocItem9": "9. Collaborative Lists - Hybrid Encryption",
+  "@cryptoTocItem9": {
+    "description": "Table of contents item 9"
+  },
+
+  "cryptoCollabListsTitle": "9. Collaborative Lists — Hybrid Encryption",
+  "@cryptoCollabListsTitle": {
+    "description": "Collaborative lists section title"
+  },
+
+  "cryptoCollabListsIntro": "Shared lists use a two-layer hybrid encryption scheme so that task data is encrypted once, yet any authorised member can independently decrypt it using only their own Nostr keypair — no trusted key server required.",
+  "@cryptoCollabListsIntro": {
+    "description": "Collaborative lists intro paragraph"
+  },
+
+  "cryptoCollabHybridTitle": "How the Hybrid Scheme Works",
+  "@cryptoCollabHybridTitle": {
+    "description": "Collaborative lists hybrid scheme subheading"
+  },
+
+  "cryptoCollabHybridDesc": "A random 256-bit AES key encrypts the list payload (AES-256-GCM). That AES key is then wrapped individually for every member using NIP-44 v2 (ECDH over secp256k1 → HKDF-SHA256 → ChaCha20-Poly1305). Each member stores one small encrypted blob; the bulk ciphertext is shared.",
+  "@cryptoCollabHybridDesc": {
+    "description": "Collaborative lists hybrid scheme description"
+  },
+
+  "cryptoCollabEncryptionFlow": "Encrypt\n  tasks (JSON) ──AES-256-GCM (random key + 12-byte nonce)──► ciphertext\n\nWrap key per member\n  owner_sk × member_pk ──ECDH──► shared_secret\n  shared_secret ──HKDF-SHA256──► wrap_key\n  wrap_key ──NIP-44 v2──► encrypted_aes_key\n\nPublish Nostr event\n  { encrypted_data, members[], encrypted_keys[] }",
+  "@cryptoCollabEncryptionFlow": {
+    "description": "Collaborative lists encryption flow code block"
+  },
+
+  "cryptoCollabMembershipTitle": "Membership Changes",
+  "@cryptoCollabMembershipTitle": {
+    "description": "Collaborative lists membership changes subheading"
+  },
+
+  "cryptoCollabAddMember": "Adding a member",
+  "@cryptoCollabAddMember": {
+    "description": "Add member bullet title"
+  },
+
+  "cryptoCollabAddMemberDesc": "Wrap the existing AES key for the new member with NIP-44 v2. No re-encryption of the list payload is required.",
+  "@cryptoCollabAddMemberDesc": {
+    "description": "Add member detail"
+  },
+
+  "cryptoCollabRemoveMember": "Removing a member (forward secrecy)",
+  "@cryptoCollabRemoveMember": {
+    "description": "Remove member bullet title"
+  },
+
+  "cryptoCollabRemoveMemberDesc": "Generate a fresh random AES key, re-encrypt the entire list, and re-wrap the new key for all remaining members. The removed member's old encrypted_aes_key becomes permanently useless.",
+  "@cryptoCollabRemoveMemberDesc": {
+    "description": "Remove member detail"
+  },
+
+  "cryptoCollabPrimitivesTitle": "Cryptographic Primitives",
+  "@cryptoCollabPrimitivesTitle": {
+    "description": "Collaborative lists primitives subheading"
+  },
+
+  "cryptoCollabPrimitivesTable": "Layer               Algorithm\n─────────────────────────────────────────────\nList encryption     AES-256-GCM\nKey agreement       ECDH / secp256k1 (NIP-44 v2)\nKey derivation      HKDF-SHA256 (inside NIP-44)\nRNG                 OsRng (OS-provided CSPRNG)\nEvent authenticity  Schnorr / secp256k1 (Nostr)",
+  "@cryptoCollabPrimitivesTable": {
+    "description": "Collaborative lists primitives table"
+  },
+
+  "cryptoCollabReference": "📚 Design doc: docs/COLLABORATIVE_LISTS_ENCRYPTION.md",
+  "@cryptoCollabReference": {
+    "description": "Collaborative lists reference link text"
+  },
+
   "cryptoFooterSecurityTitle": "🔒 Security Questions and Reports",
   "@cryptoFooterSecurityTitle": {
     "description": "Footer security title"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2257,7 +2257,7 @@
     "description": "Collaborative lists hybrid scheme description"
   },
 
-  "cryptoCollabEncryptionFlow": "Encrypt\n  tasks (JSON) ──AES-256-GCM (random key + 12-byte nonce)──► ciphertext\n\nWrap key per member\n  owner_sk × member_pk ──ECDH──► shared_secret\n  shared_secret ──HKDF-SHA256──► wrap_key\n  wrap_key ──NIP-44 v2──► encrypted_aes_key\n\nPublish Nostr event\n  { encrypted_data, members[], encrypted_keys[] }",
+  "cryptoCollabEncryptionFlow": "Encrypt\n  tasks (JSON) ──AES-256-GCM (random key + 12-byte nonce)──► ciphertext\n\nWrap key per member\n  owner_sk × member_pk ──ECDH──► shared_secret\n  shared_secret ──HKDF-SHA256──► wrap_key\n  wrap_key ──NIP-44 v2──► encrypted_aes_key\n\nPublish Nostr event\n  '{' encrypted_data, members[], encrypted_keys[] '}'",
   "@cryptoCollabEncryptionFlow": {
     "description": "Collaborative lists encryption flow code block"
   },

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -838,7 +838,7 @@
   "cryptoCollabListsIntro": "Las listas compartidas utilizan un esquema de cifrado híbrido de dos capas: los datos de tareas se cifran una sola vez, pero cualquier miembro autorizado puede descifrarlos de forma independiente usando únicamente su propio par de claves Nostr, sin necesidad de un servidor de claves de confianza.",
   "cryptoCollabHybridTitle": "Cómo Funciona el Esquema Híbrido",
   "cryptoCollabHybridDesc": "Una clave AES aleatoria de 256 bits cifra el payload de la lista (AES-256-GCM). Esa clave AES se envuelve individualmente para cada miembro usando NIP-44 v2 (ECDH sobre secp256k1 → HKDF-SHA256 → ChaCha20-Poly1305). Cada miembro almacena un pequeño blob cifrado; el texto cifrado principal es compartido.",
-  "cryptoCollabEncryptionFlow": "Cifrar\n  tareas (JSON) ──AES-256-GCM (clave aleatoria + nonce 12 bytes)──► cifrado\n\nEnvolver clave por miembro\n  owner_sk × member_pk ──ECDH──► secreto_compartido\n  secreto_compartido ──HKDF-SHA256──► clave_envoltura\n  clave_envoltura ──NIP-44 v2──► encrypted_aes_key\n\nPublicar evento Nostr\n  { encrypted_data, members[], encrypted_keys[] }",
+  "cryptoCollabEncryptionFlow": "Cifrar\n  tareas (JSON) ──AES-256-GCM (clave aleatoria + nonce 12 bytes)──► cifrado\n\nEnvolver clave por miembro\n  owner_sk × member_pk ──ECDH──► secreto_compartido\n  secreto_compartido ──HKDF-SHA256──► clave_envoltura\n  clave_envoltura ──NIP-44 v2──► encrypted_aes_key\n\nPublicar evento Nostr\n  '{' encrypted_data, members[], encrypted_keys[] '}'",
   "cryptoCollabMembershipTitle": "Cambios de Membresía",
   "cryptoCollabAddMember": "Agregar un miembro",
   "cryptoCollabAddMemberDesc": "Envuelve la clave AES existente para el nuevo miembro con NIP-44 v2. No se requiere re-cifrado del payload de la lista.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -838,7 +838,7 @@
   "cryptoCollabListsIntro": "Las listas compartidas utilizan un esquema de cifrado híbrido de dos capas: los datos de tareas se cifran una sola vez, pero cualquier miembro autorizado puede descifrarlos de forma independiente usando únicamente su propio par de claves Nostr, sin necesidad de un servidor de claves de confianza.",
   "cryptoCollabHybridTitle": "Cómo Funciona el Esquema Híbrido",
   "cryptoCollabHybridDesc": "Una clave AES aleatoria de 256 bits cifra el payload de la lista (AES-256-GCM). Esa clave AES se envuelve individualmente para cada miembro usando NIP-44 v2 (ECDH sobre secp256k1 → HKDF-SHA256 → ChaCha20-Poly1305). Cada miembro almacena un pequeño blob cifrado; el texto cifrado principal es compartido.",
-  "cryptoCollabEncryptionFlow": "Cifrar\n  tareas (JSON) ──AES-256-GCM (clave aleatoria + nonce 12 bytes)──► cifrado\n\nEnvolver clave por miembro\n  owner_sk × member_pk ──ECDH──► secreto_compartido\n  secreto_compartido ──HKDF-SHA256──► clave_envoltura\n  clave_envoltura ──NIP-44 v2──► encrypted_aes_key\n\nPublicar evento Nostr\n  '{' encrypted_data, members[], encrypted_keys[] '}'",
+  "cryptoCollabEncryptionFlow": "Cifrar\n  tareas (JSON) ──AES-256-GCM (clave aleatoria + nonce 12 bytes)──► cifrado\n\nEnvolver clave por miembro\n  owner_sk × member_pk ──ECDH──► secreto_compartido\n  secreto_compartido ──HKDF-SHA256──► clave_envoltura\n  clave_envoltura ──NIP-44 v2──► encrypted_aes_key\n\nPublicar evento Nostr\n  campos: encrypted_data, members[], encrypted_keys[]",
   "cryptoCollabMembershipTitle": "Cambios de Membresía",
   "cryptoCollabAddMember": "Agregar un miembro",
   "cryptoCollabAddMemberDesc": "Envuelve la clave AES existente para el nuevo miembro con NIP-44 v2. No se requiere re-cifrado del payload de la lista.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -833,6 +833,20 @@
   
   "cryptoTocItem8": "8. Modelo de Amenazas y Limitaciones",
   
+  "cryptoTocItem9": "9. Listas Colaborativas - Cifrado Híbrido",
+  "cryptoCollabListsTitle": "9. Listas Colaborativas — Cifrado Híbrido",
+  "cryptoCollabListsIntro": "Las listas compartidas utilizan un esquema de cifrado híbrido de dos capas: los datos de tareas se cifran una sola vez, pero cualquier miembro autorizado puede descifrarlos de forma independiente usando únicamente su propio par de claves Nostr, sin necesidad de un servidor de claves de confianza.",
+  "cryptoCollabHybridTitle": "Cómo Funciona el Esquema Híbrido",
+  "cryptoCollabHybridDesc": "Una clave AES aleatoria de 256 bits cifra el payload de la lista (AES-256-GCM). Esa clave AES se envuelve individualmente para cada miembro usando NIP-44 v2 (ECDH sobre secp256k1 → HKDF-SHA256 → ChaCha20-Poly1305). Cada miembro almacena un pequeño blob cifrado; el texto cifrado principal es compartido.",
+  "cryptoCollabEncryptionFlow": "Cifrar\n  tareas (JSON) ──AES-256-GCM (clave aleatoria + nonce 12 bytes)──► cifrado\n\nEnvolver clave por miembro\n  owner_sk × member_pk ──ECDH──► secreto_compartido\n  secreto_compartido ──HKDF-SHA256──► clave_envoltura\n  clave_envoltura ──NIP-44 v2──► encrypted_aes_key\n\nPublicar evento Nostr\n  { encrypted_data, members[], encrypted_keys[] }",
+  "cryptoCollabMembershipTitle": "Cambios de Membresía",
+  "cryptoCollabAddMember": "Agregar un miembro",
+  "cryptoCollabAddMemberDesc": "Envuelve la clave AES existente para el nuevo miembro con NIP-44 v2. No se requiere re-cifrado del payload de la lista.",
+  "cryptoCollabRemoveMember": "Eliminar un miembro (secreto hacia adelante)",
+  "cryptoCollabRemoveMemberDesc": "Genera una nueva clave AES aleatoria, re-cifra toda la lista y re-envuelve la nueva clave para todos los miembros restantes. El encrypted_aes_key antiguo del miembro eliminado queda permanentemente inútil.",
+  "cryptoCollabPrimitivesTitle": "Primitivas Criptográficas",
+  "cryptoCollabPrimitivesTable": "Capa                  Algoritmo\n─────────────────────────────────────────────\nCifrado de lista      AES-256-GCM\nAcuerdo de clave      ECDH / secp256k1 (NIP-44 v2)\nDerivación de clave   HKDF-SHA256 (dentro de NIP-44)\nRNG                   OsRng (CSPRNG del SO)\nAutenticidad evento   Schnorr / secp256k1 (Nostr)",
+  "cryptoCollabReference": "📚 Documento de diseño: docs/COLLABORATIVE_LISTS_ENCRYPTION.md",
   "cryptoFooterSecurityTitle": "🔒 Preguntas y Reportes de Seguridad",
   
   "cryptoFooterSecurityDesc": "Si descubre un problema de seguridad, repórtelo a través de GitHub Issues o Nostr (DM).",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -829,6 +829,20 @@
   
   "cryptoTocItem8": "8. 脅威モデルと制限事項",
   
+  "cryptoTocItem9": "9. 共有リスト - ハイブリッド暗号化",
+  "cryptoCollabListsTitle": "9. 共有リスト — ハイブリッド暗号化",
+  "cryptoCollabListsIntro": "共有リストは2層のハイブリッド暗号化方式を採用しています。タスクデータは一度だけ暗号化されますが、許可されたメンバーは全員、自身のNostrキーペアのみを使って独立して復号できます。信頼できる鍵サーバーは不要です。",
+  "cryptoCollabHybridTitle": "ハイブリッド方式の仕組み",
+  "cryptoCollabHybridDesc": "ランダムな256ビットのAES鍵がリストのペイロードを暗号化します（AES-256-GCM）。その鍵はメンバーごとにNIP-44 v2（ECDH over secp256k1 → HKDF-SHA256 → ChaCha20-Poly1305）を使って個別にラップされます。各メンバーは小さな暗号化ブロブを1つ保持し、バルク暗号文は共有されます。",
+  "cryptoCollabEncryptionFlow": "暗号化\n  tasks (JSON) ──AES-256-GCM (ランダム鍵 + 12バイトnonce)──► 暗号文\n\nメンバーごとに鍵をラップ\n  owner_sk × member_pk ──ECDH──► 共有シークレット\n  共有シークレット ──HKDF-SHA256──► ラップ鍵\n  ラップ鍵 ──NIP-44 v2──► encrypted_aes_key\n\nNostrイベントを公開\n  { encrypted_data, members[], encrypted_keys[] }",
+  "cryptoCollabMembershipTitle": "メンバーシップの変更",
+  "cryptoCollabAddMember": "メンバーの追加",
+  "cryptoCollabAddMemberDesc": "既存のAES鍵をNIP-44 v2で新メンバー用にラップするだけです。リストのペイロードの再暗号化は不要です。",
+  "cryptoCollabRemoveMember": "メンバーの削除（前方秘匿性）",
+  "cryptoCollabRemoveMemberDesc": "新しいランダムなAES鍵を生成し、リスト全体を再暗号化して、残りの全メンバー用に新しい鍵を再ラップします。削除されたメンバーの古いencrypted_aes_keyは永続的に無効になります。",
+  "cryptoCollabPrimitivesTitle": "使用する暗号プリミティブ",
+  "cryptoCollabPrimitivesTable": "レイヤー               アルゴリズム\n─────────────────────────────────────────────\nリスト暗号化           AES-256-GCM\n鍵共有                 ECDH / secp256k1 (NIP-44 v2)\n鍵導出                 HKDF-SHA256 (NIP-44内部)\nRNG                    OsRng (OS提供のCSPRNG)\nイベント真正性          Schnorr / secp256k1 (Nostr)",
+  "cryptoCollabReference": "📚 設計文書: docs/COLLABORATIVE_LISTS_ENCRYPTION.md",
   "cryptoFooterSecurityTitle": "🔒 セキュリティに関する質問や報告",
   
   "cryptoFooterSecurityDesc": "セキュリティ上の問題を発見した場合は、GitHubのIssueまたはNostr (DM) でご報告ください。",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -834,7 +834,7 @@
   "cryptoCollabListsIntro": "共有リストは2層のハイブリッド暗号化方式を採用しています。タスクデータは一度だけ暗号化されますが、許可されたメンバーは全員、自身のNostrキーペアのみを使って独立して復号できます。信頼できる鍵サーバーは不要です。",
   "cryptoCollabHybridTitle": "ハイブリッド方式の仕組み",
   "cryptoCollabHybridDesc": "ランダムな256ビットのAES鍵がリストのペイロードを暗号化します（AES-256-GCM）。その鍵はメンバーごとにNIP-44 v2（ECDH over secp256k1 → HKDF-SHA256 → ChaCha20-Poly1305）を使って個別にラップされます。各メンバーは小さな暗号化ブロブを1つ保持し、バルク暗号文は共有されます。",
-  "cryptoCollabEncryptionFlow": "暗号化\n  tasks (JSON) ──AES-256-GCM (ランダム鍵 + 12バイトnonce)──► 暗号文\n\nメンバーごとに鍵をラップ\n  owner_sk × member_pk ──ECDH──► 共有シークレット\n  共有シークレット ──HKDF-SHA256──► ラップ鍵\n  ラップ鍵 ──NIP-44 v2──► encrypted_aes_key\n\nNostrイベントを公開\n  '{' encrypted_data, members[], encrypted_keys[] '}'",
+  "cryptoCollabEncryptionFlow": "暗号化\n  tasks (JSON) ──AES-256-GCM (ランダム鍵 + 12バイトnonce)──► 暗号文\n\nメンバーごとに鍵をラップ\n  owner_sk × member_pk ──ECDH──► 共有シークレット\n  共有シークレット ──HKDF-SHA256──► ラップ鍵\n  ラップ鍵 ──NIP-44 v2──► encrypted_aes_key\n\nNostrイベントを公開\n  フィールド: encrypted_data, members[], encrypted_keys[]",
   "cryptoCollabMembershipTitle": "メンバーシップの変更",
   "cryptoCollabAddMember": "メンバーの追加",
   "cryptoCollabAddMemberDesc": "既存のAES鍵をNIP-44 v2で新メンバー用にラップするだけです。リストのペイロードの再暗号化は不要です。",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -834,7 +834,7 @@
   "cryptoCollabListsIntro": "共有リストは2層のハイブリッド暗号化方式を採用しています。タスクデータは一度だけ暗号化されますが、許可されたメンバーは全員、自身のNostrキーペアのみを使って独立して復号できます。信頼できる鍵サーバーは不要です。",
   "cryptoCollabHybridTitle": "ハイブリッド方式の仕組み",
   "cryptoCollabHybridDesc": "ランダムな256ビットのAES鍵がリストのペイロードを暗号化します（AES-256-GCM）。その鍵はメンバーごとにNIP-44 v2（ECDH over secp256k1 → HKDF-SHA256 → ChaCha20-Poly1305）を使って個別にラップされます。各メンバーは小さな暗号化ブロブを1つ保持し、バルク暗号文は共有されます。",
-  "cryptoCollabEncryptionFlow": "暗号化\n  tasks (JSON) ──AES-256-GCM (ランダム鍵 + 12バイトnonce)──► 暗号文\n\nメンバーごとに鍵をラップ\n  owner_sk × member_pk ──ECDH──► 共有シークレット\n  共有シークレット ──HKDF-SHA256──► ラップ鍵\n  ラップ鍵 ──NIP-44 v2──► encrypted_aes_key\n\nNostrイベントを公開\n  { encrypted_data, members[], encrypted_keys[] }",
+  "cryptoCollabEncryptionFlow": "暗号化\n  tasks (JSON) ──AES-256-GCM (ランダム鍵 + 12バイトnonce)──► 暗号文\n\nメンバーごとに鍵をラップ\n  owner_sk × member_pk ──ECDH──► 共有シークレット\n  共有シークレット ──HKDF-SHA256──► ラップ鍵\n  ラップ鍵 ──NIP-44 v2──► encrypted_aes_key\n\nNostrイベントを公開\n  '{' encrypted_data, members[], encrypted_keys[] '}'",
   "cryptoCollabMembershipTitle": "メンバーシップの変更",
   "cryptoCollabAddMember": "メンバーの追加",
   "cryptoCollabAddMemberDesc": "既存のAES鍵をNIP-44 v2で新メンバー用にラップするだけです。リストのペイロードの再暗号化は不要です。",

--- a/lib/presentation/settings/cryptography_detail_screen.dart
+++ b/lib/presentation/settings/cryptography_detail_screen.dart
@@ -498,6 +498,74 @@ class CryptographyDetailScreen extends StatelessWidget {
 
                   const SizedBox(height: 40),
 
+                  // セクション9: 共有リスト暗号化
+                  _buildSection(
+                    context,
+                    id: 'collab-lists',
+                    icon: Icons.group_outlined,
+                    title: AppLocalizations.of(context).cryptoCollabListsTitle,
+                    content: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _buildParagraph(
+                          context,
+                          AppLocalizations.of(context).cryptoCollabListsIntro,
+                        ),
+                        const SizedBox(height: 16),
+                        _buildSubheading(
+                            context,
+                            AppLocalizations.of(context)
+                                .cryptoCollabHybridTitle),
+                        _buildParagraph(
+                          context,
+                          AppLocalizations.of(context).cryptoCollabHybridDesc,
+                        ),
+                        const SizedBox(height: 16),
+                        _buildCodeBlock(
+                          context,
+                          AppLocalizations.of(context)
+                              .cryptoCollabEncryptionFlow,
+                        ),
+                        const SizedBox(height: 16),
+                        _buildSubheading(
+                            context,
+                            AppLocalizations.of(context)
+                                .cryptoCollabMembershipTitle),
+                        _buildBulletPoint(
+                          context,
+                          AppLocalizations.of(context).cryptoCollabAddMember,
+                          AppLocalizations.of(context)
+                              .cryptoCollabAddMemberDesc,
+                        ),
+                        _buildBulletPoint(
+                          context,
+                          AppLocalizations.of(context)
+                              .cryptoCollabRemoveMember,
+                          AppLocalizations.of(context)
+                              .cryptoCollabRemoveMemberDesc,
+                        ),
+                        const SizedBox(height: 16),
+                        _buildSubheading(
+                            context,
+                            AppLocalizations.of(context)
+                                .cryptoCollabPrimitivesTitle),
+                        _buildCodeBlock(
+                          context,
+                          AppLocalizations.of(context)
+                              .cryptoCollabPrimitivesTable,
+                        ),
+                        const SizedBox(height: 12),
+                        _buildLinkText(
+                          context,
+                          AppLocalizations.of(context).cryptoCollabReference,
+                          'https://github.com/higedamc/meiso/blob/main/docs/COLLABORATIVE_LISTS_ENCRYPTION.md',
+                        ),
+                      ],
+                    ),
+                  ),
+
+                  const SizedBox(height: 40),
+
                   // フッター
                   _buildFooter(context),
 
@@ -564,6 +632,7 @@ class CryptographyDetailScreen extends StatelessWidget {
           _buildTocItem(context, AppLocalizations.of(context).cryptoTocItem6),
           _buildTocItem(context, AppLocalizations.of(context).cryptoTocItem7),
           _buildTocItem(context, AppLocalizations.of(context).cryptoTocItem8),
+          _buildTocItem(context, AppLocalizations.of(context).cryptoTocItem9),
         ],
       ),
     );


### PR DESCRIPTION
## Summary

- Adds **Section 9 — Collaborative Lists (Hybrid Encryption)** to the in-app Cryptography Details screen (`cryptography_detail_screen.dart`)
- Updates table of contents to include the new section
- Adds all required localization strings in **EN / JA / ES** (`app_localizations*.dart`)

## What's covered in the new section

- Overview of the two-layer hybrid scheme (AES-256-GCM payload + NIP-44 v2 key wrapping)
- Encryption flow diagram (code block)
- Membership changes: adding members (no re-encryption needed) vs. removing members (full key rotation / forward secrecy)
- Cryptographic primitives table: AES-256-GCM, ECDH/secp256k1, HKDF-SHA256, OsRng, Schnorr
- Link to the full design doc added in #149 (`docs/COLLABORATIVE_LISTS_ENCRYPTION.md`)

## Test plan

- [ ] Build and open Settings → Cryptography Details
- [ ] Scroll to Section 9 and verify text renders correctly
- [ ] Switch locale to JA and ES, verify translations appear
- [ ] Tap the design doc link — should open GitHub URL in external browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)