### PR TITLE
feat(rust): NIP-77 negentropy 差分同期を導入 (Phase 4)

### DIFF
--- a/lib/bridge_generated.dart/api.dart
+++ b/lib/bridge_generated.dart/api.dart
@@ -9,9 +9,13 @@ import 'group_tasks_mls.dart';
 import 'group_tasks_shared.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `build_nostr_client`, `check_connection_info`, `check_connection_status`, `default_nip89_client_tag_enabled`, `default_proxy_url`, `drain_all`, `ensure_subscription_event_listener`, `fetch_events_eose`, `get_client`, `group_todos_by_list`, `list_key_from_d_tag`, `lock_recovering`, `normalize_custom_list_id`, `normalize_synced_todos`, `normalize_todo_date_string`, `push`, `receive_subscription_events`, `reconnect_with_timeout`, `reconnect`, `send_event_to_relays`, `send_event_with_result`, `subscribe`, `unsubscribe_all`, `unsubscribe`
+// These functions are ignored because they are not marked as `pub`: `build_nostr_client`, `check_connection_info`, `check_connection_status`, `default_nip89_client_tag_enabled`, `default_proxy_url`, `drain_all`, `ensure_subscription_event_listener`, `fetch_events_eose`, `get_client`, `group_todos_by_list`, `list_key_from_d_tag`, `lock_recovering`, `normalize_custom_list_id`, `normalize_synced_todos`, `normalize_todo_date_string`, `push`, `receive_subscription_events`, `reconnect_with_timeout`, `reconnect`, `send_event_to_relays`, `send_event_with_result`, `subscribe`, `sync_log`, `try_negentropy_sync`, `unsubscribe_all`, `unsubscribe`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `ClientMode`, `SubscriptionEventQueue`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
+
+/// Dart 側から購読する同期ログストリームを登録する。
+/// ホットリスタート等での再登録は新しい sink で上書きされる。
+Stream<String> initSyncLogStream() => RustLib.instance.api.crateApiInitSyncLogStream();
 
 /// 永続イベントキャッシュを初期化する。
 /// アプリ起動時に initNostrClient* より前に一度だけ呼ぶこと。

--- a/lib/bridge_generated.dart/frb_generated.dart
+++ b/lib/bridge_generated.dart/frb_generated.dart
@@ -67,7 +67,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -1949297025;
+  int get rustContentHash => -1730542590;
 
   static const kDefaultExternalLibraryLoaderConfig = ExternalLibraryLoaderConfig(
     stem: 'rust',
@@ -497,6 +497,8 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<void> crateApiInitNostrDb({required String dbDir});
+
+  Stream<String> crateApiInitSyncLogStream();
 
   Future<bool> crateApiIsCacheValid({required CachedEventInfo cacheInfo});
 
@@ -3665,13 +3667,42 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Stream<String> crateApiInitSyncLogStream() {
+    final sink = RustStreamSink<String>();
+    unawaited(
+      handler.executeNormal(
+        NormalTask(
+          callFfi: (port_) {
+            final serializer = SseSerializer(generalizedFrbRustBinding);
+            sse_encode_StreamSink_String_Sse(sink, serializer);
+            pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 105, port: port_);
+          },
+          codec: SseCodec(
+            decodeSuccessData: sse_decode_unit,
+            decodeErrorData: null,
+          ),
+          constMeta: kCrateApiInitSyncLogStreamConstMeta,
+          argValues: [sink],
+          apiImpl: this,
+        ),
+      ),
+    );
+    return sink.stream;
+  }
+
+  TaskConstMeta get kCrateApiInitSyncLogStreamConstMeta => const TaskConstMeta(
+    debugName: "init_sync_log_stream",
+    argNames: ["sink"],
+  );
+
+  @override
   Future<bool> crateApiIsCacheValid({required CachedEventInfo cacheInfo}) {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_cached_event_info(cacheInfo, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 105, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 106, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3697,7 +3728,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(storagePath, serializer);
           sse_encode_String(password, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 106, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 107, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3722,7 +3753,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(storagePath, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 107, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 108, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_String,
@@ -3757,7 +3788,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(todoJson, serializer);
           sse_encode_String(action, serializer);
           sse_encode_String(todoId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 108, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 109, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3782,7 +3813,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(nostrId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 109, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 110, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_key_package_result,
@@ -3815,7 +3846,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(groupId, serializer);
           sse_encode_String(groupName, serializer);
           sse_encode_list_String(keyPackages, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 110, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 111, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -3846,7 +3877,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(nostrId, serializer);
           sse_encode_String(groupId, serializer);
           sse_encode_String(encryptedMsg, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 111, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 112, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_record_string_string_string_string_string,
@@ -3877,7 +3908,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(nostrId, serializer);
           sse_encode_String(groupId, serializer);
           sse_encode_String(mlsMessageHex, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 112, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 113, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3903,7 +3934,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(nostrId, serializer);
           sse_encode_String(groupId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 113, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 114, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_mls_group_info,
@@ -3929,7 +3960,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(nostrId, serializer);
           sse_encode_String(groupId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 114, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 115, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3955,7 +3986,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(nostrId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 115, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 116, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -3982,7 +4013,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(nostrId, serializer);
           sse_encode_String(groupId, serializer);
           sse_encode_list_prim_u_8_loose(welcomeMsg, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 116, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 117, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4007,7 +4038,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(npub, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 117, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 118, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4032,7 +4063,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_64(timeoutMs, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 118, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 119, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_received_event,
@@ -4061,7 +4092,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_64(timeoutMs, serializer);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 119, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 120, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_received_event,
@@ -4085,7 +4116,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 120, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 121, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4110,7 +4141,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 121, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 122, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4135,7 +4166,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_64(timeoutSecs, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 122, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 123, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4161,7 +4192,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_64(timeoutSecs, serializer);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 123, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 124, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4190,7 +4221,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_group_todo_list(groupList, serializer);
           sse_encode_String(memberToRemove, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 124, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 125, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_group_todo_list,
@@ -4215,7 +4246,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_app_settings(settings, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 125, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 126, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_event_send_result,
@@ -4241,7 +4272,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_app_settings(settings, serializer);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 126, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 127, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_event_send_result,
@@ -4272,7 +4303,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(storagePath, serializer);
           sse_encode_String(secretKey, serializer);
           sse_encode_String(password, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 127, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 128, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4297,7 +4328,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_group_todo_list(groupList, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 128, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 129, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_event_send_result,
@@ -4323,7 +4354,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(storagePath, serializer);
           sse_encode_String(publicKey, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 129, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 130, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4348,7 +4379,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_String(relays, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 130, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 131, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_event_send_result,
@@ -4374,7 +4405,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_String(relays, serializer);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 131, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 132, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_event_send_result,
@@ -4399,7 +4430,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(eventJson, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 132, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 133, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_event_send_result,
@@ -4428,7 +4459,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(eventJson, serializer);
           sse_encode_list_String(relayUrls, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 133, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 134, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_event_send_result,
@@ -4454,7 +4485,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(eventJson, serializer);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 134, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 135, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_event_send_result,
@@ -4479,7 +4510,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_bool(enabled, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 135, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 136, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4504,7 +4535,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(userAgent, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 136, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 137, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4539,7 +4570,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(groupNpub, serializer);
           sse_encode_String(groupName, serializer);
           sse_encode_u_64(keyEpoch, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 137, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 138, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4565,7 +4596,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(groupNsecHex, serializer);
           sse_encode_String(metaJson, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 138, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 139, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4591,7 +4622,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(groupNsecHex, serializer);
           sse_encode_String(taskJson, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 139, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 140, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4622,7 +4653,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(recipientNsecHex, serializer);
           sse_encode_String(senderPubkeyHex, serializer);
           sse_encode_String(ciphertext, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 140, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 141, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_invitation_payload,
@@ -4648,7 +4679,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(groupNsecHex, serializer);
           sse_encode_String(eventJson, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 141, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 142, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4674,7 +4705,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(groupNsecHex, serializer);
           sse_encode_String(eventJson, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 142, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 143, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4705,7 +4736,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(inviterNsecHex, serializer);
           sse_encode_String(recipientPubkeyHex, serializer);
           sse_encode_String(payloadJson, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 143, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 144, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4729,7 +4760,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 144, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 145, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_group_key,
@@ -4754,7 +4785,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(groupNsecHex, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 145, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 146, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4779,7 +4810,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(payloadJson, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 146, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 147, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_invitation_payload,
@@ -4805,7 +4836,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(sha256Hex, serializer);
           sse_encode_i_64(fileSize, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 147, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 148, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4836,7 +4867,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(sha256Hex, serializer);
           sse_encode_i_64(fileSize, serializer);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 148, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 149, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4861,7 +4892,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(unsignedEventJson, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 149, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 150, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4887,7 +4918,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(url, serializer);
           sse_encode_String(method, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 150, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 151, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4918,7 +4949,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(url, serializer);
           sse_encode_String(method, serializer);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 151, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 152, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -4943,7 +4974,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(filtersJson, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 152, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 153, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_subscription_info,
@@ -4969,7 +5000,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(filtersJson, serializer);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 153, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 154, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_subscription_info,
@@ -4993,7 +5024,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 154, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 155, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -5018,7 +5049,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 155, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 156, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -5043,7 +5074,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(subscriptionId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 156, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 157, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -5069,7 +5100,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(subscriptionId, serializer);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 157, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 158, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -5093,7 +5124,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 158, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 159, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_app_settings,
@@ -5118,7 +5149,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 159, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 160, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_app_settings,
@@ -5144,7 +5175,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(recipientPublicKeyHex, serializer);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 160, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 161, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -5168,7 +5199,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 161, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 162, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -5193,7 +5224,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 162, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 163, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -5219,7 +5250,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(recipientPublicKeyHex, serializer);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 163, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 164, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -5243,7 +5274,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 164, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 165, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_todo_data,
@@ -5269,7 +5300,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_i_64(since, serializer);
           sse_encode_u_64(timeoutSecs, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 165, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 166, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_todo_data,
@@ -5300,7 +5331,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_i_64(since, serializer);
           sse_encode_u_64(timeoutSecs, serializer);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 166, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 167, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_todo_data,
@@ -5325,7 +5356,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 167, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 168, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_todo_data,
@@ -5349,7 +5380,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 168, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 169, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_tor_mode,
@@ -5374,7 +5405,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_String(relays, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 169, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 170, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -5400,7 +5431,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_String(relays, serializer);
           sse_encode_opt_String(clientId, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 170, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 171, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -5425,7 +5456,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(eventJson, serializer);
-          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 171, port: port_);
+          pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 172, port: port_);
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -5477,6 +5508,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return MeisoNostrClientImpl.frbInternalDcoDecode(raw as List<dynamic>);
+  }
+
+  @protected
+  RustStreamSink<String> dco_decode_StreamSink_String_Sse(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    throw UnimplementedError();
   }
 
   @protected
@@ -6092,6 +6129,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return MeisoNostrClientImpl.frbInternalSseDecode(sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
+  }
+
+  @protected
+  RustStreamSink<String> sse_decode_StreamSink_String_Sse(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    throw UnimplementedError('Unreachable ()');
   }
 
   @protected
@@ -6859,6 +6902,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize((self as MeisoNostrClientImpl).frbInternalSseEncode(move: null), serializer);
+  }
+
+  @protected
+  void sse_encode_StreamSink_String_Sse(RustStreamSink<String> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(
+      self.setupAndSerialize(
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_String,
+          decodeErrorData: sse_decode_AnyhowException,
+        ),
+      ),
+      serializer,
+    );
   }
 
   @protected

--- a/lib/bridge_generated.dart/frb_generated.io.dart
+++ b/lib/bridge_generated.dart/frb_generated.io.dart
@@ -43,6 +43,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RustStreamSink<String> dco_decode_StreamSink_String_Sse(dynamic raw);
+
+  @protected
   String dco_decode_String(dynamic raw);
 
   @protected
@@ -245,6 +248,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   MeisoNostrClient sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMeisoNostrClient(
     SseDeserializer deserializer,
   );
+
+  @protected
+  RustStreamSink<String> sse_decode_StreamSink_String_Sse(SseDeserializer deserializer);
 
   @protected
   String sse_decode_String(SseDeserializer deserializer);
@@ -454,6 +460,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     MeisoNostrClient self,
     SseSerializer serializer,
   );
+
+  @protected
+  void sse_encode_StreamSink_String_Sse(RustStreamSink<String> self, SseSerializer serializer);
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);

--- a/lib/bridge_generated.dart/frb_generated.web.dart
+++ b/lib/bridge_generated.dart/frb_generated.web.dart
@@ -45,6 +45,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  RustStreamSink<String> dco_decode_StreamSink_String_Sse(dynamic raw);
+
+  @protected
   String dco_decode_String(dynamic raw);
 
   @protected
@@ -247,6 +250,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   MeisoNostrClient sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerMeisoNostrClient(
     SseDeserializer deserializer,
   );
+
+  @protected
+  RustStreamSink<String> sse_decode_StreamSink_String_Sse(SseDeserializer deserializer);
 
   @protected
   String sse_decode_String(SseDeserializer deserializer);
@@ -456,6 +462,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     MeisoNostrClient self,
     SseSerializer serializer,
   );
+
+  @protected
+  void sse_encode_StreamSink_String_Sse(RustStreamSink<String> self, SseSerializer serializer);
 
   @protected
   void sse_encode_String(String self, SseSerializer serializer);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -75,6 +75,18 @@ void main() async {
     } catch (e) {
       AppLogger.error('Nostr DB 初期化エラー (in-memory で継続)', error: e, tag: 'INIT');
     }
+
+    // Rust 側の同期メタデータログ（negentropy 等）を Talker に転送する。
+    // メタデータ（リレー数・件数）のみでイベント内容や鍵は含まれない。
+    try {
+      rust_api.initSyncLogStream().listen(
+        (msg) => AppLogger.info(msg, tag: 'RUST_SYNC'),
+        onError: (Object e) =>
+            AppLogger.warning('Rust sync log stream error: $e', tag: 'INIT'),
+      );
+    } catch (e) {
+      AppLogger.warning('Rust sync log stream 初期化失敗: $e', tag: 'INIT');
+    }
   } catch (e, stackTrace) {
     AppLogger.error(
       'Rust初期化エラー',

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -213,6 +213,15 @@ const FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 /// replaceable event は 1 リレーの EOSE で十分なので短くてよい。
 const EOSE_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(2500);
 
+/// NIP-77 negentropy 対応確認のタイムアウト。
+/// 非対応リレーはこの時間内に NEG-ERR 等で判明し、EOSE フェッチへ
+/// フォールバックする。
+const NEGENTROPY_INITIAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// negentropy reconciliation 全体の上限時間。
+/// 超過時は従来の EOSE フェッチにフォールバックする。
+const NEGENTROPY_OVERALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
+
 /// 永続イベントキャッシュ (nostr-lmdb)。
 /// init_nostr_db() で一度だけ開き、全クライアントで共有する
 /// （LMDB は同一プロセスから同じ環境を複数回開くべきではないため）。
@@ -932,12 +941,83 @@ impl MeisoNostrClient {
     /// `fetch_events` は全リレーの EOSE かタイムアウトまで待つため、無応答リレーが
     /// 1 本でもあると固定タイムアウト分ブロックする。replaceable event は 1 リレー
     /// の EOSE で十分なので、最初の EOSE（または短い無通信）で打ち切って高速化する。
+    /// NIP-77 negentropy でリレーと差分同期し、ローカルDBから読み出す。
+    ///
+    /// - 対応リレーが 1 つ以上あれば不足イベントのみダウンロードされ
+    ///   （差分ゼロなら 1 往復 ~100 バイト）、受信イベントは通常の
+    ///   ingest 経路で永続 DB (nostr-lmdb) に保存される。
+    /// - 永続 DB 未初期化時は None（in-memory の MemoryDatabase は
+    ///   デフォルトでイベント本体を保存しないため query が空になる）。
+    /// - 全リレー非対応/失敗/タイムアウト時も None を返し、呼び出し側が
+    ///   従来の EOSE フェッチにフォールバックする。
+    async fn try_negentropy_sync(&self, filter: Filter) -> Option<Vec<Event>> {
+        // 永続 DB がなければ差分同期の結果を読み出せない
+        NOSTR_DB.get()?;
+
+        let opts = SyncOptions::default()
+            .initial_timeout(NEGENTROPY_INITIAL_TIMEOUT)
+            .direction(SyncDirection::Down);
+
+        // 応答しないリレーで reconciliation が長引くケースの上限
+        let sync_result = match tokio::time::timeout(
+            NEGENTROPY_OVERALL_TIMEOUT,
+            self.client.sync(filter.clone(), &opts),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => {
+                dev_println!(
+                    "ℹ️ negentropy sync timed out ({}s), falling back to EOSE fetch",
+                    NEGENTROPY_OVERALL_TIMEOUT.as_secs(),
+                );
+                return None;
+            }
+        };
+
+        match sync_result {
+            Ok(output) if !output.success.is_empty() => {
+                match self.client.database().query(filter).await {
+                    Ok(events) => {
+                        dev_println!(
+                            "✅ negentropy sync: {} relay(s) reconciled, {} received, reading local DB",
+                            output.success.len(),
+                            output.received.len(),
+                        );
+                        Some(events.into_iter().collect())
+                    }
+                    Err(e) => {
+                        dev_eprintln!("⚠️ local DB query failed after negentropy sync: {}", e);
+                        None
+                    }
+                }
+            }
+            Ok(output) => {
+                dev_println!(
+                    "ℹ️ negentropy unsupported/failed on all relays ({} failed), falling back to EOSE fetch",
+                    output.failed.len(),
+                );
+                None
+            }
+            Err(e) => {
+                dev_println!("ℹ️ negentropy sync error: {}, falling back to EOSE fetch", e);
+                None
+            }
+        }
+    }
+
     /// `timeout` は最悪ケースの上限。
     async fn fetch_events_eose(
         &self,
         filter: Filter,
         timeout: Duration,
     ) -> Result<Vec<Event>> {
+        // まず NIP-77 negentropy 差分同期を試す（対応リレー + 永続DBがある場合）
+        if let Some(mut events) = self.try_negentropy_sync(filter.clone()).await {
+            events.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+            return Ok(events);
+        }
+
         let output = self.client.subscribe(filter, None).await?;
         let sub_id = output.id().clone();
         let mut notifications = self.client.notifications();

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -1836,18 +1836,31 @@ impl MeisoNostrClient {
         let total = relays.len();
         let mut statuses = Vec::with_capacity(total);
 
+        let mut detail: Vec<String> = Vec::with_capacity(total);
         for (url, relay) in &relays {
-            let is_connected = relay.status() == nostr_sdk::RelayStatus::Connected;
+            let status = relay.status();
+            let is_connected = status == nostr_sdk::RelayStatus::Connected;
             if is_connected {
                 connected += 1;
             }
+            detail.push(format!("{}={}", url, status));
             statuses.push(RelayStatusInfo {
                 url: url.to_string(),
                 connected: is_connected,
             });
         }
 
-        dev_println!("🔌 Relay status: {}/{} connected", connected, total);
+        // 全接続が健全なときは静かに、不健全なときだけ Talker に実状態を出す
+        if connected < total {
+            sync_log(format!(
+                "🔌 relay status {}/{} connected: {}",
+                connected,
+                total,
+                detail.join(", "),
+            ));
+        } else {
+            dev_println!("🔌 Relay status: {}/{} connected", connected, total);
+        }
         Ok(RelayConnectionInfo {
             connected,
             total,
@@ -1937,10 +1950,10 @@ impl MeisoNostrClient {
     ///
     /// その後、1 つ以上のリレーが実際に Connected になるまで待つ。
     pub(crate) async fn reconnect_with_timeout(&self, timeout_secs: u64) -> Result<()> {
-        dev_println!(
-            "🔄 Ensuring relay connections (timeout: {}s)...",
+        sync_log(format!(
+            "🔄 ensuring relay connections (timeout: {}s)...",
             timeout_secs
-        );
+        ));
 
         let relays = self.client.relays().await;
         if relays.is_empty() {
@@ -1951,20 +1964,20 @@ impl MeisoNostrClient {
             match relay.status() {
                 nostr_sdk::RelayStatus::Connected => {}
                 nostr_sdk::RelayStatus::Pending | nostr_sdk::RelayStatus::Connecting => {
-                    dev_println!("  ⏳ {} connection already in progress", url);
+                    sync_log(format!("  ⏳ {} connection already in progress", url));
                 }
                 nostr_sdk::RelayStatus::Disconnected => {
                     // バックオフ待ちを打ち切り、即時再試行させる
                     relay.disconnect();
                     relay.connect();
-                    dev_println!("  🔁 {} retrying immediately", url);
+                    sync_log(format!("  🔁 {} retrying immediately", url));
                 }
                 nostr_sdk::RelayStatus::Initialized | nostr_sdk::RelayStatus::Terminated => {
                     relay.connect();
-                    dev_println!("  🔌 {} connecting", url);
+                    sync_log(format!("  🔌 {} connecting", url));
                 }
                 nostr_sdk::RelayStatus::Banned | nostr_sdk::RelayStatus::Sleeping => {
-                    dev_println!("  💤 {} skipped (status={})", url, relay.status());
+                    sync_log(format!("  💤 {} skipped (status={})", url, relay.status()));
                 }
             }
         }
@@ -1978,11 +1991,11 @@ impl MeisoNostrClient {
                 .filter(|r| r.status() == nostr_sdk::RelayStatus::Connected)
                 .count();
             if connected > 0 {
-                dev_println!("✅ {}/{} relays connected", connected, relays.len());
+                sync_log(format!("✅ reconnect: {}/{} relays connected", connected, relays.len()));
                 return Ok(());
             }
             if tokio::time::Instant::now() >= deadline {
-                dev_eprintln!("⚠️ Reconnection timeout ({}s)", timeout_secs);
+                sync_log(format!("⚠️ reconnect timeout ({}s)", timeout_secs));
                 return Err(anyhow::anyhow!("Reconnection timeout"));
             }
             tokio::time::sleep(Duration::from_millis(200)).await;

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -229,6 +229,31 @@ const NEGENTROPY_OVERALL_TIMEOUT: std::time::Duration = std::time::Duration::fro
 static NOSTR_DB: once_cell::sync::OnceCell<std::sync::Arc<nostr_lmdb::NostrLMDB>> =
     once_cell::sync::OnceCell::new();
 
+/// Rust 側の同期メタデータログ（negentropy 等）を Dart（Talker）へ流すストリーム。
+/// ⚠️ ここにはリレー数・件数などのメタデータのみを流すこと。
+/// イベント内容・鍵・トークン等の機微情報は絶対に流さない（security audit C-1）。
+static SYNC_LOG_SINK: once_cell::sync::Lazy<
+    std::sync::Mutex<Option<crate::frb_generated::StreamSink<String>>>,
+> = once_cell::sync::Lazy::new(|| std::sync::Mutex::new(None));
+
+/// Dart 側から購読する同期ログストリームを登録する。
+/// ホットリスタート等での再登録は新しい sink で上書きされる。
+pub fn init_sync_log_stream(sink: crate::frb_generated::StreamSink<String>) {
+    if let Ok(mut guard) = SYNC_LOG_SINK.lock() {
+        *guard = Some(sink);
+    }
+}
+
+/// 同期メタデータログ。debug ビルドでは stdout にも出す。
+fn sync_log(msg: String) {
+    dev_println!("{}", msg);
+    if let Ok(guard) = SYNC_LOG_SINK.lock() {
+        if let Some(sink) = guard.as_ref() {
+            let _ = sink.add(msg);
+        }
+    }
+}
+
 /// 永続イベントキャッシュを初期化する。
 /// アプリ起動時に initNostrClient* より前に一度だけ呼ぶこと。
 /// 2 回目以降の呼び出しは no-op（成功を返す）。
@@ -954,6 +979,13 @@ impl MeisoNostrClient {
         // 永続 DB がなければ差分同期の結果を読み出せない
         NOSTR_DB.get()?;
 
+        // ログ用: 対象 kind（経路の識別のため。内容は含めない）
+        let kinds: Vec<u16> = filter
+            .kinds
+            .as_ref()
+            .map(|k| k.iter().map(|kind| kind.as_u16()).collect())
+            .unwrap_or_default();
+
         let opts = SyncOptions::default()
             .initial_timeout(NEGENTROPY_INITIAL_TIMEOUT)
             .direction(SyncDirection::Down);
@@ -967,10 +999,11 @@ impl MeisoNostrClient {
         {
             Ok(result) => result,
             Err(_) => {
-                dev_println!(
-                    "ℹ️ negentropy sync timed out ({}s), falling back to EOSE fetch",
+                sync_log(format!(
+                    "⏱️ negentropy kinds={:?}: timed out ({}s), falling back to EOSE fetch",
+                    kinds,
                     NEGENTROPY_OVERALL_TIMEOUT.as_secs(),
-                );
+                ));
                 return None;
             }
         };
@@ -979,28 +1012,37 @@ impl MeisoNostrClient {
             Ok(output) if !output.success.is_empty() => {
                 match self.client.database().query(filter).await {
                     Ok(events) => {
-                        dev_println!(
-                            "✅ negentropy sync: {} relay(s) reconciled, {} received, reading local DB",
+                        sync_log(format!(
+                            "✅ negentropy kinds={:?}: {} relay(s) reconciled, {} received, {} events from local DB",
+                            kinds,
                             output.success.len(),
                             output.received.len(),
-                        );
+                            events.len(),
+                        ));
                         Some(events.into_iter().collect())
                     }
                     Err(e) => {
-                        dev_eprintln!("⚠️ local DB query failed after negentropy sync: {}", e);
+                        sync_log(format!(
+                            "⚠️ negentropy kinds={:?}: local DB query failed: {}",
+                            kinds, e,
+                        ));
                         None
                     }
                 }
             }
             Ok(output) => {
-                dev_println!(
-                    "ℹ️ negentropy unsupported/failed on all relays ({} failed), falling back to EOSE fetch",
+                sync_log(format!(
+                    "ℹ️ negentropy kinds={:?}: unsupported/failed on all relays ({} failed), falling back to EOSE fetch",
+                    kinds,
                     output.failed.len(),
-                );
+                ));
                 None
             }
             Err(e) => {
-                dev_println!("ℹ️ negentropy sync error: {}, falling back to EOSE fetch", e);
+                sync_log(format!(
+                    "ℹ️ negentropy kinds={:?}: sync error: {}, falling back to EOSE fetch",
+                    kinds, e,
+                ));
                 None
             }
         }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1949297025;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1730542590;
 
 // Section: executor
 
@@ -4243,6 +4243,44 @@ fn wire__crate__api__init_nostr_db_impl(
         },
     )
 }
+fn wire__crate__api__init_sync_log_stream_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "init_sync_log_stream",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_sink =
+                <StreamSink<String, flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(
+                    &mut deserializer,
+                );
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok({
+                        crate::api::init_sync_log_stream(api_sink);
+                    })?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__is_cache_valid_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -6775,6 +6813,14 @@ impl SseDecode
     }
 }
 
+impl SseDecode for StreamSink<String, flutter_rust_bridge::for_generated::SseCodec> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <String>::sse_decode(deserializer);
+        return StreamSink::deserialize(inner);
+    }
+}
+
 impl SseDecode for String {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -8005,195 +8051,196 @@ fn pde_ffi_dispatcher_primary_impl(
             data_len,
         ),
         104 => wire__crate__api__init_nostr_db_impl(port, ptr, rust_vec_len, data_len),
-        105 => wire__crate__api__is_cache_valid_impl(port, ptr, rust_vec_len, data_len),
-        106 => wire__crate__api__load_encrypted_secret_key_impl(port, ptr, rust_vec_len, data_len),
-        107 => wire__crate__api__load_public_key_impl(port, ptr, rust_vec_len, data_len),
-        108 => wire__crate__api__mls_add_todo_impl(port, ptr, rust_vec_len, data_len),
-        109 => wire__crate__api__mls_create_key_package_impl(port, ptr, rust_vec_len, data_len),
-        110 => wire__crate__api__mls_create_todo_group_impl(port, ptr, rust_vec_len, data_len),
-        111 => wire__crate__api__mls_decrypt_todo_impl(port, ptr, rust_vec_len, data_len),
-        112 => wire__crate__api__mls_encrypt_group_event_content_impl(
+        105 => wire__crate__api__init_sync_log_stream_impl(port, ptr, rust_vec_len, data_len),
+        106 => wire__crate__api__is_cache_valid_impl(port, ptr, rust_vec_len, data_len),
+        107 => wire__crate__api__load_encrypted_secret_key_impl(port, ptr, rust_vec_len, data_len),
+        108 => wire__crate__api__load_public_key_impl(port, ptr, rust_vec_len, data_len),
+        109 => wire__crate__api__mls_add_todo_impl(port, ptr, rust_vec_len, data_len),
+        110 => wire__crate__api__mls_create_key_package_impl(port, ptr, rust_vec_len, data_len),
+        111 => wire__crate__api__mls_create_todo_group_impl(port, ptr, rust_vec_len, data_len),
+        112 => wire__crate__api__mls_decrypt_todo_impl(port, ptr, rust_vec_len, data_len),
+        113 => wire__crate__api__mls_encrypt_group_event_content_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        113 => wire__crate__api__mls_get_group_info_impl(port, ptr, rust_vec_len, data_len),
-        114 => wire__crate__api__mls_get_listen_key_impl(port, ptr, rust_vec_len, data_len),
-        115 => wire__crate__api__mls_init_db_impl(port, ptr, rust_vec_len, data_len),
-        116 => wire__crate__api__mls_join_group_impl(port, ptr, rust_vec_len, data_len),
-        117 => wire__crate__api__npub_to_hex_impl(port, ptr, rust_vec_len, data_len),
-        118 => {
+        114 => wire__crate__api__mls_get_group_info_impl(port, ptr, rust_vec_len, data_len),
+        115 => wire__crate__api__mls_get_listen_key_impl(port, ptr, rust_vec_len, data_len),
+        116 => wire__crate__api__mls_init_db_impl(port, ptr, rust_vec_len, data_len),
+        117 => wire__crate__api__mls_join_group_impl(port, ptr, rust_vec_len, data_len),
+        118 => wire__crate__api__npub_to_hex_impl(port, ptr, rust_vec_len, data_len),
+        119 => {
             wire__crate__api__receive_subscription_events_impl(port, ptr, rust_vec_len, data_len)
         }
-        119 => wire__crate__api__receive_subscription_events_with_client_id_impl(
+        120 => wire__crate__api__receive_subscription_events_with_client_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        120 => wire__crate__api__reconnect_to_relays_impl(port, ptr, rust_vec_len, data_len),
-        121 => wire__crate__api__reconnect_to_relays_with_client_id_impl(
+        121 => wire__crate__api__reconnect_to_relays_impl(port, ptr, rust_vec_len, data_len),
+        122 => wire__crate__api__reconnect_to_relays_with_client_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        122 => wire__crate__api__reconnect_to_relays_with_timeout_impl(
+        123 => wire__crate__api__reconnect_to_relays_with_timeout_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        123 => wire__crate__api__reconnect_to_relays_with_timeout_and_client_id_impl(
+        124 => wire__crate__api__reconnect_to_relays_with_timeout_and_client_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        124 => wire__crate__api__remove_member_from_group_task_list_impl(
+        125 => wire__crate__api__remove_member_from_group_task_list_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        125 => wire__crate__api__save_app_settings_impl(port, ptr, rust_vec_len, data_len),
-        126 => wire__crate__api__save_app_settings_with_client_id_impl(
+        126 => wire__crate__api__save_app_settings_impl(port, ptr, rust_vec_len, data_len),
+        127 => wire__crate__api__save_app_settings_with_client_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        127 => wire__crate__api__save_encrypted_secret_key_impl(port, ptr, rust_vec_len, data_len),
-        128 => {
+        128 => wire__crate__api__save_encrypted_secret_key_impl(port, ptr, rust_vec_len, data_len),
+        129 => {
             wire__crate__api__save_group_task_list_to_nostr_impl(port, ptr, rust_vec_len, data_len)
         }
-        129 => wire__crate__api__save_public_key_impl(port, ptr, rust_vec_len, data_len),
-        130 => wire__crate__api__save_relay_list_impl(port, ptr, rust_vec_len, data_len),
-        131 => {
+        130 => wire__crate__api__save_public_key_impl(port, ptr, rust_vec_len, data_len),
+        131 => wire__crate__api__save_relay_list_impl(port, ptr, rust_vec_len, data_len),
+        132 => {
             wire__crate__api__save_relay_list_with_client_id_impl(port, ptr, rust_vec_len, data_len)
         }
-        132 => wire__crate__api__send_signed_event_impl(port, ptr, rust_vec_len, data_len),
-        133 => {
+        133 => wire__crate__api__send_signed_event_impl(port, ptr, rust_vec_len, data_len),
+        134 => {
             wire__crate__api__send_signed_event_to_relays_impl(port, ptr, rust_vec_len, data_len)
         }
-        134 => wire__crate__api__send_signed_event_with_client_id_impl(
+        135 => wire__crate__api__send_signed_event_with_client_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        135 => {
+        136 => {
             wire__crate__api__set_nip89_client_tag_enabled_impl(port, ptr, rust_vec_len, data_len)
         }
-        136 => {
+        137 => {
             wire__crate__api__set_relay_websocket_user_agent_impl(port, ptr, rust_vec_len, data_len)
         }
-        137 => wire__crate__api__shared_build_invitation_payload_impl(
+        138 => wire__crate__api__shared_build_invitation_payload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        138 => {
+        139 => {
             wire__crate__api__shared_build_signed_meta_event_impl(port, ptr, rust_vec_len, data_len)
         }
-        139 => {
+        140 => {
             wire__crate__api__shared_build_signed_task_event_impl(port, ptr, rust_vec_len, data_len)
         }
-        140 => wire__crate__api__shared_decrypt_invitation_from_sender_impl(
+        141 => wire__crate__api__shared_decrypt_invitation_from_sender_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        141 => wire__crate__api__shared_decrypt_meta_event_impl(port, ptr, rust_vec_len, data_len),
-        142 => wire__crate__api__shared_decrypt_task_event_impl(port, ptr, rust_vec_len, data_len),
-        143 => wire__crate__api__shared_encrypt_invitation_for_recipient_impl(
+        142 => wire__crate__api__shared_decrypt_meta_event_impl(port, ptr, rust_vec_len, data_len),
+        143 => wire__crate__api__shared_decrypt_task_event_impl(port, ptr, rust_vec_len, data_len),
+        144 => wire__crate__api__shared_encrypt_invitation_for_recipient_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        144 => wire__crate__api__shared_generate_group_key_impl(port, ptr, rust_vec_len, data_len),
-        145 => wire__crate__api__shared_npub_from_nsec_impl(port, ptr, rust_vec_len, data_len),
-        146 => wire__crate__api__shared_parse_invitation_payload_impl(
+        145 => wire__crate__api__shared_generate_group_key_impl(port, ptr, rust_vec_len, data_len),
+        146 => wire__crate__api__shared_npub_from_nsec_impl(port, ptr, rust_vec_len, data_len),
+        147 => wire__crate__api__shared_parse_invitation_payload_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        147 => wire__crate__api__sign_blossom_auth_event_impl(port, ptr, rust_vec_len, data_len),
-        148 => wire__crate__api__sign_blossom_auth_event_with_client_id_impl(
+        148 => wire__crate__api__sign_blossom_auth_event_impl(port, ptr, rust_vec_len, data_len),
+        149 => wire__crate__api__sign_blossom_auth_event_with_client_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        149 => {
+        150 => {
             wire__crate__api__sign_event_with_ephemeral_key_impl(port, ptr, rust_vec_len, data_len)
         }
-        150 => wire__crate__api__sign_nip98_auth_event_impl(port, ptr, rust_vec_len, data_len),
-        151 => wire__crate__api__sign_nip98_auth_event_with_client_id_impl(
+        151 => wire__crate__api__sign_nip98_auth_event_impl(port, ptr, rust_vec_len, data_len),
+        152 => wire__crate__api__sign_nip98_auth_event_with_client_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        152 => wire__crate__api__start_subscription_impl(port, ptr, rust_vec_len, data_len),
-        153 => wire__crate__api__start_subscription_with_client_id_impl(
+        153 => wire__crate__api__start_subscription_impl(port, ptr, rust_vec_len, data_len),
+        154 => wire__crate__api__start_subscription_with_client_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        154 => wire__crate__api__stop_all_subscriptions_impl(port, ptr, rust_vec_len, data_len),
-        155 => wire__crate__api__stop_all_subscriptions_with_client_id_impl(
+        155 => wire__crate__api__stop_all_subscriptions_impl(port, ptr, rust_vec_len, data_len),
+        156 => wire__crate__api__stop_all_subscriptions_with_client_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        156 => wire__crate__api__stop_subscription_impl(port, ptr, rust_vec_len, data_len),
-        157 => wire__crate__api__stop_subscription_with_client_id_impl(
+        157 => wire__crate__api__stop_subscription_impl(port, ptr, rust_vec_len, data_len),
+        158 => wire__crate__api__stop_subscription_with_client_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        158 => wire__crate__api__sync_app_settings_impl(port, ptr, rust_vec_len, data_len),
-        159 => wire__crate__api__sync_app_settings_with_client_id_impl(
+        159 => wire__crate__api__sync_app_settings_impl(port, ptr, rust_vec_len, data_len),
+        160 => wire__crate__api__sync_app_settings_with_client_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        160 => wire__crate__api__sync_group_invitations_impl(port, ptr, rust_vec_len, data_len),
-        161 => wire__crate__api__sync_relay_list_impl(port, ptr, rust_vec_len, data_len),
-        162 => {
+        161 => wire__crate__api__sync_group_invitations_impl(port, ptr, rust_vec_len, data_len),
+        162 => wire__crate__api__sync_relay_list_impl(port, ptr, rust_vec_len, data_len),
+        163 => {
             wire__crate__api__sync_relay_list_with_client_id_impl(port, ptr, rust_vec_len, data_len)
         }
-        163 => wire__crate__api__sync_shared_invitations_impl(port, ptr, rust_vec_len, data_len),
-        164 => wire__crate__api__sync_todo_list_impl(port, ptr, rust_vec_len, data_len),
-        165 => wire__crate__api__sync_todo_list_since_impl(port, ptr, rust_vec_len, data_len),
-        166 => wire__crate__api__sync_todo_list_since_with_client_id_impl(
+        164 => wire__crate__api__sync_shared_invitations_impl(port, ptr, rust_vec_len, data_len),
+        165 => wire__crate__api__sync_todo_list_impl(port, ptr, rust_vec_len, data_len),
+        166 => wire__crate__api__sync_todo_list_since_impl(port, ptr, rust_vec_len, data_len),
+        167 => wire__crate__api__sync_todo_list_since_with_client_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        167 => {
+        168 => {
             wire__crate__api__sync_todo_list_with_client_id_impl(port, ptr, rust_vec_len, data_len)
         }
-        168 => wire__crate__api__tor_mode_default_impl(port, ptr, rust_vec_len, data_len),
-        169 => wire__crate__api__update_relay_list_impl(port, ptr, rust_vec_len, data_len),
-        170 => wire__crate__api__update_relay_list_with_client_id_impl(
+        169 => wire__crate__api__tor_mode_default_impl(port, ptr, rust_vec_len, data_len),
+        170 => wire__crate__api__update_relay_list_impl(port, ptr, rust_vec_len, data_len),
+        171 => wire__crate__api__update_relay_list_with_client_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        171 => wire__crate__api__verify_amber_signature_impl(port, ptr, rust_vec_len, data_len),
+        172 => wire__crate__api__verify_amber_signature_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -8798,6 +8845,13 @@ impl SseEncode
         let (ptr, size) = self.sse_encode_raw();
         <usize>::sse_encode(ptr, serializer);
         <i32>::sse_encode(size, serializer);
+    }
+}
+
+impl SseEncode for StreamSink<String, flutter_rust_bridge::for_generated::SseCodec> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        unimplemented!("")
     }
 }
 


### PR DESCRIPTION
## 概要

**Stacked PR**（base: #152 の head）。マージは #152 の後に。

同期パフォーマンス改善の Phase 4。全フェッチ経路の共通ヘルパー `fetch_events_eose` の先頭に NIP-77 negentropy 差分同期（`client.sync()`, Down 方向）を差し込み、対応リレーがあれば**不足イベントのみ**をダウンロードしてローカル DB (nostr-lmdb, Phase 2 で導入) から読み出す。**差分ゼロなら 1 往復 ~100 バイト**で同期完了。

## 恩恵を受ける経路（9 箇所すべて一括）

TODO リスト full/delta（秘密鍵・Amber 両モード）/ アプリ設定 (kind:30078) / リレーリスト (kind:10002) / リスト名 / カスタムリストメタデータ — いずれも author 指定の replaceable セットで、negentropy と最も相性が良い形。

## フォールバック（従来の EOSE 早期終了フェッチ）

- 永続 DB 未初期化時（in-memory `MemoryDatabase` はデフォルトでイベント本体を保存せず query が空になるため、negentropy 経路を使わない）
- 全リレーが NIP-77 非対応/失敗時（対応判定は 3 秒）
- reconciliation 全体が 8 秒を超えた時

損はしない設計: 対応リレー（strfry 系: relay.damus.io / nos.lol 等）では劇的に軽く、非対応リレーでは従来と同じ。

## 検証

- cargo check（host / aarch64-linux-android）: green
- cargo test --lib: 16 passed / 2 failed — 失敗 2 件はこの lineage に残るレガシー HMAC テスト（#153 でモジュールごと削除済み。本 PR とは無関係）
- /security-max-audit: Critical/High ゼロ（受信専用・署名検証込み標準 ingest・タイムアウト有界）
- 実機: strfry 系リレー相手に 2 回目以降の同期がローカル DB 読みで完結することをログで確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)